### PR TITLE
[Update] 各種ログイン関連画面のレイアウト作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:email])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :name])
   end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -3,3 +3,4 @@
 
 @import 'header';
 @import 'top';
+@import 'devise';

--- a/app/javascript/stylesheets/devise.scss
+++ b/app/javascript/stylesheets/devise.scss
@@ -1,0 +1,13 @@
+.devise-box{
+  background-color: #f9f9f9;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+  width: 70%;
+  margin-top: 200px;
+}
+.term-title{
+  background-color: #fff;
+  border-radius: 10px 10px 0 0;
+  padding: 25px 0 10px 25px;
+  font-size: 18px;
+}

--- a/app/javascript/stylesheets/devise.scss
+++ b/app/javascript/stylesheets/devise.scss
@@ -3,7 +3,7 @@
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   border-radius: 10px;
   width: 70%;
-  margin-top: 200px;
+  margin-top: 180px;
 }
 .term-title{
   background-color: #fff;

--- a/app/views/admin/registrations/new.html.erb
+++ b/app/views/admin/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Sign up</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "admin/shared/error_messages", resource: resource %>
+  <%= render "admins/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />
@@ -26,4 +26,4 @@
   </div>
 <% end %>
 
-<%= render "admin/shared/links" %>
+<%= render "admins/shared/links" %>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,26 +1,24 @@
-<h2>Log in</h2>
+<div class="container">
+  <div class="row">
+    <div class="offset-3 col-9">
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="devise-box mx-auto">
+        <!--管理者ログインフォーム-->
+        <h5 class="term-title ml-2 pb-3 font-weight-bold">管理者ログイン</h5>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+        <%= form_with model: @admin, url: admin_session_path do |f| %>
+          <div class="my-4">
+            <%= f.email_field :email, placeholder: "Email", class: "form-control mx-auto", style: "width: 85%;" %>
+          </div>
+          <div class="my-4">
+            <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class: "form-control mx-auto", style: "width: 85%;" %>
+          </div>
+          <div class="text-center">
+            <%= f.submit "ログイン", class: "btn btn-outline-success mt-1 mb-4", style: "width: 85%;" %>
+          </div>
+        <% end %>
+      </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "admin/shared/links" %>
+</div>

--- a/app/views/public/passwords/new.html.erb
+++ b/app/views/public/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<h2>Forgot your password?</h2>
+<div class="container">
+  <div class="row">
+    <div class="offset-3 col-9">
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
+      <div class="devise-box mx-auto">
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <!--再送フォーム-->
+        <h5 class="term-title ml-2 pb-3 font-weight-bold">パスワードの再設定</h5>
+
+        <%= form_with model: @user, url: user_password_path do |f| %>
+          <div class="my-4">
+            <%= f.email_field :email, placeholder: "Email", class: "form-control mx-auto", style: "width: 85%;" %>
+          </div>
+          <div class="text-center">
+            <%= f.submit "パスワード再設定用のリンクを送信", class: "btn btn-outline-info mt-1 mb-4", style: "width: 85%;" %>
+          </div>
+        <% end %>
+
+      </div>
+
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "public/shared/links" %>
+</div>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,29 +1,33 @@
-<h2>Sign up</h2>
+<div class="container">
+  <div class="row">
+    <div class="offset-3 col-9">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
+      <div class="devise-box mx-auto">
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <!--新規登録フォーム-->
+        <h5 class="term-title ml-2 pb-3 font-weight-bold">新規会員登録</h5>
+
+        <%= form_with model: @user, url: user_registration_path do |f| %>
+          <div class="my-4">
+            <%= f.email_field :email, placeholder: "Email", class: "form-control mx-auto", style: "width: 85%;" %>
+          </div>
+          <div class="my-4">
+            <%= f.text_field :name, placeholder: "ユーザー名", class: "form-control mx-auto", style: "width: 85%;" %>
+          </div>
+          <div class="my-4">
+            <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード（10文字以上）", class: "form-control mx-auto", style: "width: 85%;" %>
+            <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード（確認用）", class: "form-control mx-auto mt-2", style: "width: 85%;" %>
+          </div>
+          <div class="text-center">
+            <%= f.submit "新規会員登録", class: "btn btn-outline-primary mt-1 mb-4", style: "width: 85%;" %>
+          </div>
+        <% end %>
+
+        <!--ログインリンク-->
+        <h5 class="font-weight-bold ml-5 pb-4" style="font-size: 16px;">既に登録済みの方は<%= link_to "こちら", new_user_session_path %></h5>
+
+      </div>
+
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "public/shared/links" %>
+</div>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -4,7 +4,7 @@
 
       <div class="devise-box mx-auto">
 
-        <!--新規登録フォーム-->
+        <!--新規会員登録フォーム-->
         <h5 class="term-title ml-2 pb-3 font-weight-bold">新規会員登録</h5>
 
         <%= form_with model: @user, url: user_registration_path do |f| %>
@@ -24,7 +24,7 @@
         <% end %>
 
         <!--ログインリンク-->
-        <h5 class="font-weight-bold ml-5 pb-4" style="font-size: 16px;">既に登録済みの方は<%= link_to "こちら", new_user_session_path %></h5>
+        <h5 class="ml-5 pb-4" style="font-size: 16px;"><%= link_to "既に登録済みの方はこちら", new_user_session_path %></h5>
 
       </div>
 

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,26 +1,39 @@
-<h2>Log in</h2>
+<div class="container">
+  <div class="row">
+    <div class="offset-3 col-9">
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="devise-box mx-auto">
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+        <!--ログインフォーム-->
+        <h5 class="term-title ml-2 pb-3 font-weight-bold">ログイン</h5>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+        <%= form_with model: @user, url: user_session_path do |f| %>
+          <div class="my-4">
+            <%= f.email_field :email, placeholder: "Email", class: "form-control mx-auto", style: "width: 85%;" %>
+          </div>
+          <div class="my-4">
+            <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class: "form-control mx-auto", style: "width: 85%;" %>
+          </div>
+          <!--ログイン情報を記憶する-->
+          <% if devise_mapping.rememberable? %>
+            <div class="form-check ml-3">
+              <%= f.check_box :remember_me %>
+              <%= f.label :remember_me do %>
+                ログイン情報を記憶する
+              <% end %>
+            </div>
+          <% end %>
+          <div class="text-center">
+            <%= f.submit "ログイン", class: "btn btn-outline-success mt-1 mb-4", style: "width: 85%;" %>
+          </div>
+        <% end %>
+
+        <!--新規会員登録リンク-->
+        <h5 class="ml-5 pb-1" style="font-size: 16px;"><%= link_to "未登録の方はこちら", new_user_registration_path %></h5>
+        <h5 class="ml-5 pb-4" style="font-size: 16px;"><%= link_to "パスワードを忘れた方はこちら", new_user_password_path %></h5>
+
+      </div>
+
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "public/shared/links" %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 
@@ -77,5 +77,18 @@ Rails.application.configure do
   config.hosts.clear
 
   config.active_job.queue_adapter = :inline
+
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    port:                 587,
+    address:              'smtp.gmail.com',
+    domain:               'smtp.gmail.com',
+    user_name:            ENV['MAIL_ADDRESS'],
+    password:             ENV['MAIL_PASSWORD'],
+    authentication:       'login',
+    enable_starttls_auto: true
+  }
 
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 10..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'gatchugokugo@gmail.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
以下の変更点を含みます。

### 各種ログイン関連画面のレイアウト作成
- Sign Up画面
- Sign In画面
- Forgot your password画面
- Admin側Sign In画面

### パスワード再設定リンクの送信元アドレスの設定
送信元のログイン情報は.envに格納した上で、
Forgot your password画面の操作から指定のメールアドレスにリンクが送られることを確認しました。