### PR TITLE
[Update] エラー文の実装

### DIFF
--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -3,6 +3,7 @@
     <div class="offset-3 col-9">
 
       <div class="devise-box mx-auto">
+
         <!--管理者ログインフォーム-->
         <h5 class="term-title ml-2 pb-3 font-weight-bold">管理者ログイン</h5>
 

--- a/app/views/layouts/_errors.html.erb
+++ b/app/views/layouts/_errors.html.erb
@@ -1,0 +1,13 @@
+<% if obj.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger" role="alert">
+      <h5 class="alert-heading"><%= obj.errors.count %> 件のエラーが発生しました。</h5>
+      <hr>
+        <ul>
+          <% obj.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,17 @@
+<div id="flash" class="offset-3 col-9 mx-auto">
+  <% flash.each do |message_type, message| %>
+    <% if flash[:notice] %>
+      <div class="alert alert-success text-center">
+        <%= message %>
+      </div>
+    <% else %>
+      <div class="alert alert-danger text-center">
+        <%= message %>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<script>
+  setTimeout("$('#flash').fadeOut()", 2000);
+</script>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,15 +1,17 @@
-<div id="flash" class="offset-3 col-9 mx-auto">
-  <% flash.each do |message_type, message| %>
-    <% if flash[:notice] %>
-      <div class="alert alert-success text-center">
-        <%= message %>
-      </div>
-    <% else %>
-      <div class="alert alert-danger text-center">
-        <%= message %>
-      </div>
+<div class="position-relative">
+  <div id="flash" class="col-9 mx-auto position-absolute" style="z-index: 99999;">
+    <% flash.each do |message_type, message| %>
+      <% if flash[:notice] %>
+        <div class="alert alert-success text-center">
+          <%= message %>
+        </div>
+      <% else %>
+        <div class="alert alert-danger text-center">
+          <%= message %>
+        </div>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
 </div>
 
 <script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,6 +64,8 @@
         </div>
 
         <div class="col-9">
+          <!--フラッシュメッセージ-->
+          <%= render 'layouts/flash' %>
           <%= yield %>
         </div>
 

--- a/app/views/public/passwords/new.html.erb
+++ b/app/views/public/passwords/new.html.erb
@@ -1,6 +1,9 @@
 <div class="container">
   <div class="row">
     <div class="offset-3 col-9">
+      
+      <!--エラーメッセージ-->
+      <%= render "layouts/errors", obj: @user %>
 
       <div class="devise-box mx-auto">
 

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,6 +1,9 @@
 <div class="container">
   <div class="row">
     <div class="offset-3 col-9">
+      
+      <!--エラーメッセージ-->
+      <%= render "layouts/errors", obj: @user %>
 
       <div class="devise-box mx-auto">
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,3 +33,16 @@ ja:
       answer_rank:
         normal: "一般"
         master: "マスター"
+  activerecord:
+    attributes:
+      user:
+        email: "メールアドレス"
+        password: "パスワード"
+        name: "ユーザー名"
+        introduction: "自己紹介"
+        gender: "性別"
+        age: "年齢層"
+        study_background: "中国語学習歴"
+        living_are: "居住地域"
+        answer_rank: "アンサーランク"
+        is_deleted: "会員ステータス"


### PR DESCRIPTION
以下の変更点を含みます。

### エラーメッセージ・フラッシュメッセージの実装
app>views>layoutsフォルダ内にそれぞれ部分テンプレートとして格納されています。
フラッシュメッセージにはposition: absolute;とz-index: 99999;を適用し、表示時に他の要素に影響を及ぼさないようにしました。
また、表示されるエラー文に含まれるカラム名の各日本語訳を追加しました。