### PR TITLE
[Update] public/today_wordsのshow画面作成

### DIFF
--- a/app/controllers/public/today_words_controller.rb
+++ b/app/controllers/public/today_words_controller.rb
@@ -1,9 +1,13 @@
 class Public::TodayWordsController < Public::ApplicationController
-  
+
   def index
+    @today_words = TodayWord.all.page(params[:page]).order(id: "DESC").per(10)
   end
 
   def show
+    @today_word = TodayWord.find(params[:id])
+    @previous_word = TodayWord.where("id < ?", @today_word).order(id: "DESC").first
+    @next_word = TodayWord.where("id > ?", @today_word).order(:id).first
   end
-  
+
 end

--- a/app/controllers/public/today_words_controller.rb
+++ b/app/controllers/public/today_words_controller.rb
@@ -1,13 +1,17 @@
 class Public::TodayWordsController < Public::ApplicationController
 
   def index
-    @today_words = TodayWord.all.page(params[:page]).order(id: "DESC").per(10)
+    @today_words = TodayWord.where(is_active: true).page(params[:page]).order(id: "DESC").per(10)
   end
 
   def show
-    @today_word = TodayWord.find(params[:id])
-    @previous_word = TodayWord.where("id < ?", @today_word).order(id: "DESC").first
-    @next_word = TodayWord.where("id > ?", @today_word).order(:id).first
+    @today_word = TodayWord.find_by(id: params[:id])
+    @previous_word = TodayWord.where("id < ? AND is_active = ?", @today_word, true).order(id: "DESC").first
+    @next_word = TodayWord.where("id > ? AND is_active = ?", @today_word, true).order(:id).first
+
+    if @today_word.nil? || !@today_word.is_active
+      redirect_to today_words_path, alert: "単語が見つかりません。"
+    end
   end
 
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -2,5 +2,5 @@
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 
 @import 'header';
-@import 'top';
+@import 'common';
 @import 'devise';

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -1,4 +1,4 @@
-.top-box{
+.content-box{
   background-color: rgba(255, 255, 255, 0.5);
   padding: 20px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
@@ -30,5 +30,16 @@
   hr {
     margin-bottom: 1rem;
     width: 95%;
+  }
+}
+
+.word_card{
+  .word-term{
+    width: 16%;
+  }
+  .description{
+  border-radius: 10px;
+  width: 95%;
+  background-color: white;
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,8 +54,11 @@
             <%= link_to "https://twitter.com", class: "mx-2" do %>
               <i class="fa-brands fa-twitter" style="color: #000000;"></i>
             <% end %>
-            <%= link_to "https://m.weibo.cn/", class: "mx-2" do %>
-              <i class="fa-brands fa-weibo" style="color: #000000;"></i>
+            <%= link_to "https://instagram.com/", class: "mx-2" do %>
+              <i class="fa-brands fa-instagram" style="color: #000000;"></i>
+            <% end %>
+            <%= link_to "https://tiktok.com/", class: "mx-2" do %>
+              <i class="fa-brands fa-tiktok" style="color: #000000;"></i>
             <% end %>
           </div>
 

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -13,7 +13,7 @@
   <div class="row">
 
     <div class="offset-1 col-8">
-      <div class="top-box mt-4 mx-auto pl-3", style="height: 96%">
+      <div class="content-box mt-4 mx-auto pl-3", style="height: 96%">
         <!--1つの行に2記事を表示する-->
         <div class="row mx-auto w-100">
           <% @posts.each do |post| %>
@@ -50,7 +50,7 @@
 
     <!--ニュースのジャンル表示サイドバー-->
     <div class="col-3">
-      <div class="top-box mt-4 mx-auto", style="height: 96%">
+      <div class="content-box mt-4 mx-auto", style="height: 96%">
         <table class="table table-borderless">
           <thead>
             <th>ジャンル一覧</th>
@@ -73,7 +73,7 @@
   <!--新着質問板-->
   <div class="row">
     <div class="offset-1 col-11">
-      <div class="top-box mt-4 mx-auto">
+      <div class="content-box mt-4 mx-auto">
 
         <div class="row mt-3">
           <span class="col-3 h3 ml-5 font-weight-bold">新着質問板</span>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -28,7 +28,7 @@
                     <%= post.genre.name %>
                   </div>
                   <div class="news-caption ml-3 mr-1">
-                    <%= post.title %>
+                    <%= truncate(post.title, length: 22, omission: '...') %>
                   </div>
                   <div class="m-3 text-dark" style="font-size: 12px">
                     <i class="far fa-clock"></i>
@@ -88,7 +88,7 @@
         <% @questions.each do |question| %>
           <div class="question mt-3 border mx-auto">
             <div class="question-title m-3">
-              <%= link_to question.title, question_path(question) %>
+              <%= link_to truncate(question.title, length: 34, omission: '...'), question_path(question) %>
             </div>
             <hr>
             <!--回答者情報-->

--- a/app/views/public/today_words/index.html.erb
+++ b/app/views/public/today_words/index.html.erb
@@ -1,2 +1,22 @@
-<h1>Public::TodayWords#index</h1>
-<p>Find me in app/views/public/today_words/index.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <h3 class="pt-5 ml-5 font-weight-bold">今日の中国語一覧</h3>
+
+      <div class="content-box mt-4">
+
+        <!--1枠-->
+        <% @today_words.each do |today_word| %>
+          <%= link_to today_word.pinyin, today_word_path(today_word) %>
+          <%= today_word.chinese %>
+          <%= today_word.japanese %>
+          <%= today_word.example_chinese %>
+        <% end %>
+
+      </div>
+    </div>
+  </div>
+
+
+</div>

--- a/app/views/public/today_words/show.html.erb
+++ b/app/views/public/today_words/show.html.erb
@@ -1,2 +1,60 @@
-<h1>Public::TodayWords#show</h1>
-<p>Find me in app/views/public/today_words/show.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="offset-1 col-11">
+      <div class="content-box word_card" style="margin-top: 100px">
+
+      <!--単語見出し-->
+      <div class="text-center mb-4">
+        <h3><%= @today_word.pinyin %></h5>
+        <h1 class="font-weight-bold" style="font-size: 50px;"><%= @today_word.chinese %></h3>
+      </div>
+
+        <!--単語詳細-->
+        <table class="table table-borderless">
+          <tr>
+            <td class="word-term h5 border text-center">意味</td>
+            <td class="h5 pl-4"><%= @today_word.japanese %></td>
+          </tr>
+          <td><!--空行--></td>
+          <tr>
+            <td rowspan="2" class="word-term h5 border text-center align-middle">用法</td>
+            <td class="h5 pl-4"><%= @today_word.example_chinese %></td>
+          </tr>
+          <tr>
+            <td class="h5 pl-4"><%= @today_word.example_japanese %></td>
+          </tr>
+          <td><!--空行--></td>
+          <tr>
+            <td class="word-term h5 border text-center">同義語</td>
+            <td class="h5 pl-4"><%= @today_word.synonym %></td>
+          </tr>
+        </table>
+
+        <!--コラム表示欄-->
+        <div class="description border mx-auto mt-5 p-3">
+          <h3 class="font-weight-bold"><i class="fa-regular fa-lightbulb"></i> コラム</h2>
+          <p class="p-1" style="font-size: 18px;"><%= @today_word.description %></p>
+        </div>
+
+      </div>
+
+      <div class="row my-4 pl-4 mx-auto">
+        <div class="col-3">
+          <% if @previous_word %>
+            <%= link_to today_word_path(@previous_word), class: "btn btn-primary" do %>
+              <i class="fa-solid fa-left-long"></i> 前の単語へ
+            <% end %>
+          <% end %>
+        </div>
+        <div class="offset-6 col-3">
+          <% if @next_word %>
+            <%= link_to today_word_path(@next_word), class: "btn btn-primary" do %>
+              次の単語へ <i class="fa-solid fa-right-long"></i>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -55,3 +55,7 @@ ja:
         description: "一言解説"
         synonym: "同義語"
         is_active: "公開ステータス"
+      # question:
+      #   user_id: "会員ID"
+      #   title: "タイトル"
+      #   body: "質問文"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ User.create!(
   ]
 )
 
-1.times do |n|
+10.times do |n|
   User.create!(
     email: "user#{n}@gmail.com",
     password: "0000000000",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ User.create!(
   ]
 )
 
-10.times do |n|
+1.times do |n|
   User.create!(
     email: "user#{n}@gmail.com",
     password: "0000000000",


### PR DESCRIPTION
以下の変更点を含みます。

### ヘッダー内ソーシャルアイコンの変更
weibo => Instagram, TikTokに変更。リンク先も併せて変更しました。

### stylesheet名とsheet内タグの名称変更、適用済みのタグをview内で変更
javascript>stylesheets内に格納されていたtop.scssの名称をcommon.scssに変更。
併せて、本シート内で使用されていたクラス「.top-box」の名称を「.content-box」に変更。

### public/today_wordsのshow画面作成
index画面は未着手。詳細画面の遷移先が存在しない場合に一覧画面に遷移させる処理も併せて記述。

### TOP画面において、各要素が一定以上の文字数を持つ場合に...と表記されるよう変更
以下に適用。
- ニュース欄内ニュースタイトル
- 質問板欄内質問タイトル