### PR TITLE
[Update] ニュース管理/ジャンル管理関連画面作成

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -21,6 +21,14 @@ class Admin::GenresController < Admin::ApplicationController
   end
 
   def update
+    @genre = Genre.find(params[:id])
+    if @genre.update(genre_params)
+      flash[:notice] = "ジャンル名の更新に成功しました。"
+      redirect_to request.referer
+    else
+      flash[:alert] = "ジャンル名の更新に失敗しました。"
+      redirect_to request.referer
+    end
   end
 
   private

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,18 +1,33 @@
 class Admin::GenresController < Admin::ApplicationController
-  
+
   def create
+    @genre = Genre.new(genre_params)
+    if @genre.save
+      flash[:notice] = "ジャンルの作成に成功しました。"
+      redirect_to request.referer
+    else
+      flash[:alert] = "ジャンルの作成に失敗しました。"
+      @genres = Genre.all
+      redirect_to request.referer
+    end
   end
-  
+
   def index
   end
 
   def edit
   end
-  
+
   def update
   end
-  
+
   def destroy
   end
-  
+
+  private
+
+  def genre_params
+    params.require(:genre).permit(:name)
+  end
+
 end

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,19 +1,23 @@
 class Admin::GenresController < Admin::ApplicationController
 
   def create
-    @genre = Genre.new(genre_params)
-    if @genre.save
-      flash[:notice] = "ジャンルの作成に成功しました。"
+    if Genre.count >= 13
+      flash[:alert] = "作成可能なジャンルは最大13項目です。"
       redirect_to request.referer
     else
-      flash[:alert] = "ジャンルの作成に失敗しました。"
-      @genres = Genre.all
-      redirect_to request.referer
+      @genre = Genre.new(genre_params)
+      if @genre.save
+        flash[:notice] = "ジャンルの作成に成功しました。"
+        redirect_to request.referer
+      else
+        flash[:alert] = "ジャンルの作成に失敗しました。"
+        redirect_to request.referer
+      end
     end
   end
 
   def index
-    @genres = Genre.all.page(params[:page]).order(:id).per(10)
+    @genres = Genre.all.order(:id)
   end
 
   def update

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -13,6 +13,7 @@ class Admin::GenresController < Admin::ApplicationController
   end
 
   def index
+    @genres = Genre.all.page(params[:page]).order(:id).per(10)
   end
 
   def update

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -15,13 +15,7 @@ class Admin::GenresController < Admin::ApplicationController
   def index
   end
 
-  def edit
-  end
-
   def update
-  end
-
-  def destroy
   end
 
   private

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,21 +1,48 @@
 class Admin::PostsController < Admin::ApplicationController
 
   def new
+    @post = Post.new
+    @genres = Genre.all
+    @genre = Genre.new
   end
 
   def create
+    @post = Post.new(post_params)
+    if @post.save
+      redirect_to admin_posts_path
+    else
+      @genres = Genre.all
+      render :new
+    end
   end
 
   def index
+    @posts = Post.all.page(params[:page]).order(id: "DESC").per(10)
   end
 
   def edit
+    @post = Post.find(params[:id])
   end
 
   def update
+    @post = Post.find(params[:id])
+    if @post.update(post_params)
+      redirect_to admin_posts_path
+    else
+      render :edit
+    end
   end
 
   def destroy
+    @post = Post.find(params[:id])
+    @post.destroy
+    redirect_to admin_posts_path
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:genre_id, :title, :body, :is_active, :image)
   end
 
 end

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -22,6 +22,8 @@ class Admin::PostsController < Admin::ApplicationController
 
   def edit
     @post = Post.find(params[:id])
+    @genres = Genre.all
+    @genre = Genre.new
   end
 
   def update
@@ -29,6 +31,7 @@ class Admin::PostsController < Admin::ApplicationController
     if @post.update(post_params)
       redirect_to admin_posts_path
     else
+      @genres = Genre.all
       render :edit
     end
   end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -2,4 +2,6 @@ class Genre < ApplicationRecord
 
   has_many :posts
 
+  validates :name, presence: true, length: { maximum: 6 }
+
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -2,6 +2,6 @@ class Genre < ApplicationRecord
 
   has_many :posts
 
-  validates :name, presence: true, length: { maximum: 6 }
+  validates :name, presence: true, uniqueness: true, length: { maximum: 6 }
 
 end

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,2 +1,0 @@
-<h1>Admin::Genres#edit</h1>
-<p>Find me in app/views/admin/genres/edit.html.erb</p>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -83,7 +83,7 @@
 
     // 引数で指定された要素をスライドダウンさせ、出現させる処理
     function slideDown(element) {
-      element.fadeIn(300);
+      element.slideDown(300);
       $(document).on("click", outsideClick); // 表示中は`outsideClick`関数を有効にする
     }
 
@@ -96,7 +96,7 @@
 
     //引数で指定された要素をスライドアップさせ、引っ込ませる処理
     function slideUp(element) {
-      element.fadeOut(300);
+      element.slideUp(300);
       $(document).off("click", outsideClick); // 非表示中は`outsideClick`関数を無効にする
     }
   });
@@ -123,9 +123,7 @@
       var editInput = row.find(".genre-edit-input");
       var editButton = row.find(".edit-button");
 
-      var newName = editInput.val();
-      nameCell.text(newName);
-      nameCell.show();
+      nameCell.text(editInput.val()).show();
       editInput.hide();
       $(this).hide();
       editButton.show();

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -47,9 +47,17 @@
           <tbody>
             <tr>
               <td class="align-middle"><%= genre.id %></td>
-              <td class="align-middle"><%= genre.name %></td>
-              <td class="align-middle"><%= genre.posts.count %></td>
-              <td><div class="py-2 px-3 btn btn-success btn-sm">編集</div></td>
+              <%= form_with model: [:admin, genre], url: admin_genre_path(genre) do |f| %>
+                <td class="align-middle">
+                  <span class="genre-name"><%= genre.name %></span>
+                  <%= f.text_field :name, placeholder: "ジャンル名を入力", class: "genre-edit-input", style: "display: none;" %>
+                </td>
+                <td class="align-middle"><%= genre.posts.count %></td>
+                <td>
+                  <div class="py-2 px-3 btn btn-success btn-sm edit-button">編集</div>
+                  <%= f.submit "保存", class: "py-2 px-3 btn btn-primary btn-sm save-button", style: "display: none;" %>
+                </td>
+              <% end %>
             </tr>
           </tbody>
         <% end %>
@@ -91,5 +99,36 @@
       element.fadeOut(300);
       $(document).off("click", outsideClick); // 非表示中は`outsideClick`関数を無効にする
     }
+  });
+</script>
+
+<!--編集ボタン押下後、フォームが出現し保存ボタンに切り替わる-->
+<script>
+  $(document).ready(function() {
+    $(".edit-button").click(function() {
+      var row = $(this).closest("tr");
+      var nameCell = row.find(".genre-name");
+      var editInput = row.find(".genre-edit-input");
+      var saveButton = row.find(".save-button");
+
+      nameCell.hide();
+      editInput.show().focus();
+      saveButton.show();
+      $(this).hide();
+    });
+
+    $(".save-button").click(function() {
+      var row = $(this).closest("tr");
+      var nameCell = row.find(".genre-name");
+      var editInput = row.find(".genre-edit-input");
+      var editButton = row.find(".edit-button");
+
+      var newName = editInput.val();
+      nameCell.text(newName);
+      nameCell.show();
+      editInput.hide();
+      $(this).hide();
+      editButton.show();
+    });
   });
 </script>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -105,7 +105,7 @@
 <!--編集ボタン押下後、フォームが出現し保存ボタンに切り替わる-->
 <script>
   $(document).ready(function() {
-    $(".edit-button").click(function() {
+    $(".edit-button").click(function() { //編集ボタンが押された時の処理
       var row = $(this).closest("tr");
       var nameCell = row.find(".genre-name");
       var editInput = row.find(".genre-edit-input");
@@ -117,13 +117,13 @@
       $(this).hide();
     });
 
-    $(".save-button").click(function() {
+    $(".save-button").click(function() { //保存ボタンが押された時の処理
       var row = $(this).closest("tr");
       var nameCell = row.find(".genre-name");
       var editInput = row.find(".genre-edit-input");
       var editButton = row.find(".edit-button");
 
-      nameCell.text(editInput.val()).show();
+      nameCell.text(editInput.val()).show(); //「nameCell」のテキストを「editInput」の値に置き換えて表示
       editInput.hide();
       $(this).hide();
       editButton.show();

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,2 +1,102 @@
-<h1>Admin::Genres#index</h1>
-<p>Find me in app/views/admin/genres/index.html.erb</p>
+<div class="container my-5">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <div class="row">
+        <div class="col-3">
+           <h5 class="term-title ml-2 font-weight-bold">ジャンル管理</h5>
+        </div>
+
+        <!--ジャンル新規登録欄（ポップアップ表示）-->
+        <div class="col-10 mx-auto form-group" id="new-genre-form"
+             style="display: none; position: absolute; top: 30%; left: 50%; transform: translate(-50%, -50%); background-color: rgba(0, 0, 0, 0.6); padding: 30px; z-index: 99999; border-radius: 10px;">
+          <table class="table table-borderless">
+              <tr>
+                <td>
+                  <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
+                    <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
+                    <%= f.submit "ジャンル作成", class:"col-3 btn btn-primary" %><br>
+                    <p class="text-white pt-3"> ※作成をやめる場合は画面外をクリック</p>
+                  <% end %>
+                </td>
+              </tr>
+          </table>
+        </div>
+
+        <!--ジャンル作成ボタン-->
+        <div class="offset-6 col-3 mt-3">
+          <div class="py-2 px-3 btn btn-primary" id="new-genre-button">
+             <i class="fa-solid fa-tags fa-lg"></i> ジャンル作成
+          </div>
+        </div>
+      </div>
+
+      <!--各列カラム名-->
+      <table class="table table-colored mt-3">
+        <thead>
+          <tr>
+            <th>ジャンルID</th>
+            <th>ジャンル名</th>
+            <th>記事の投稿数</th>
+            <th></th>
+          </tr>
+        </thead>
+
+        <!--ジャンル一覧-->
+        <% @genres.each do |genre| %>
+          <tbody>
+            <tr>
+              <td class="align-middle"><%= genre.id %></td>
+              <td class="align-middle"><%= genre.name %></td>
+              <td class="align-middle"><%= genre.posts.count %></td>
+              <td><div class="py-2 px-3 btn btn-success btn-sm">編集</div></td>
+            </tr>
+          </tbody>
+        <% end %>
+
+      </table>
+
+      <!--ページネーションの設定-->
+      <div class="row">
+        <div class="mt-2 mx-auto">
+          <%= paginate @genres, theme: 'bootstrap-5' %>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!--「ジャンル作成」ボタン押下時に発火-->
+<script>
+  // HTMLドキュメントが読み込まれた後に実行される関数
+  $(document).ready(function() {
+    var newGenreButton = $("#new-genre-button");
+    var newGenreForm = $("#new-genre-form");
+
+    // ジャンル作成ボタンがクリックされたとき
+    newGenreButton.on("click", function() {
+      event.stopPropagation(); // ここでクリックイベントの伝播を停止しなければ以下の`outsideClick`関数と同時に発火してしまい、想定と異なる挙動を生む
+      slideDown(newGenreForm);
+    });
+
+    // 引数で指定された要素をスライドダウンさせ、出現させる処理
+    function slideDown(element) {
+      element.fadeIn(300);
+      $(document).on("click", outsideClick); // 表示中は`outsideClick`関数を有効にする
+    }
+
+    // ポップアップ表示画面外をクリックすることでスライドアップさせる
+    function outsideClick(event) {
+      if (!$(event.target).closest(newGenreForm).length) { //「クリックされた要素が内部である場合には数値が返され、それ以外の場合は0となる」の否定形
+        slideUp(newGenreForm);
+      }
+    }
+
+    //引数で指定された要素をスライドアップさせ、引っ込ませる処理
+    function slideUp(element) {
+      element.fadeOut(300);
+      $(document).off("click", outsideClick); // 非表示中は`outsideClick`関数を無効にする
+    }
+  });
+</script>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -3,8 +3,8 @@
     <div class="offset-1 col-11">
 
       <div class="row">
-        <div class="col-3">
-           <h5 class="term-title ml-2 font-weight-bold">ジャンル管理</h5>
+        <div class="col-6">
+           <h5 class="term-title ml-2 font-weight-bold">ジャンル管理（最大13項目）</h5>
         </div>
 
         <!--ジャンル新規登録欄（ポップアップ表示）-->
@@ -24,7 +24,7 @@
         </div>
 
         <!--ジャンル作成ボタン-->
-        <div class="offset-6 col-3 mt-3">
+        <div class="offset-3 col-3 mt-3">
           <div class="py-2 px-3 btn btn-primary" id="new-genre-button">
              <i class="fa-solid fa-tags fa-lg"></i> ジャンル作成
           </div>
@@ -55,13 +55,6 @@
         <% end %>
 
       </table>
-
-      <!--ページネーションの設定-->
-      <div class="row">
-        <div class="mt-2 mx-auto">
-          <%= paginate @genres, theme: 'bootstrap-5' %>
-        </div>
-      </div>
 
     </div>
   </div>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -1,2 +1,140 @@
-<h1>Admin::Posts#edit</h1>
-<p>Find me in app/views/admin/posts/edit.html.erb</p>
+<div class="container my-5">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <!--エラーメッセージ-->
+      <%= render 'layouts/errors', obj: @post %>
+
+      <h5 class="term-title ml-2 font-weight-bold">ニュース編集</h5>
+
+      <!--ジャンル新規登録欄（ポップアップ表示）-->
+      <div class="col-10 mx-auto form-group" id="new-genre-form"
+           style="display: none; position: absolute; top: 30%; left: 50%; transform: translate(-50%, -50%); background-color: rgba(0, 0, 0, 0.6); padding: 30px; z-index: 99999; border-radius: 10px;">
+        <table class="table table-borderless">
+            <tr>
+              <td>
+                <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
+                  <%= f.text_field :name, placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
+                  <%= f.submit "ジャンル作成", class:"col-3 btn btn-primary" %><br>
+                  <p class="text-white pt-3"> ※作成をやめる場合は画面外をクリック</p>
+                <% end %>
+              </td>
+            </tr>
+        </table>
+      </div>
+
+      <div class="mt-4 form-group">
+        <%= form_with model: [:admin, @post], url: admin_post_path do |f| %>
+          <!--記事編集フォーム-->
+          <table class="table table-borderless">
+            <tr>
+              <td class="align-middle font-weight-bold" style="width: 30%">ジャンル</td>
+              <td>
+                <%= f.select :genre_id,
+                    options_for_select([["新しくジャンルを作成する", "new"]].concat(@genres.map { |genre| [genre.name, genre.id] }), @post.genre_id), #@post.genre_idをデフォルトの選択肢とする
+                    { include_blank: "-- 選択してください --" },
+                    {required: true, class: "form-control", style: "width: 75%;", id: "genre-select" } %>
+              </td>
+            </tr>
+            <tr>
+              <td class="align-middle font-weight-bold" style="width: 30%">タイトル</td>
+              <td><%= f.text_field :title, placeholder: "記事タイトル", class: "form-control"%></td>
+            </tr>
+            <tr>
+              <td class="align-middle font-weight-bold" style="width: 30%">本文</td>
+              <td><%= f.text_area :body, placeholder: "記事本文", class: "form-control", style: "height: 130px;" %></td>
+            </tr>
+            <tr>
+              <td class="align-middle font-weight-bold" style="width: 30%">見出し画像</td>
+              <td>
+                <%= f.file_field :image, accept: "image/png, image/jpeg" %><br>
+                <!--プレビュー表示-->
+                <img class="mt-2" id="image-preview" alt="プレビュー" style="max-width: 150px; border: solid thin lightgray; border-radius: 5px;">
+              </td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold" style="width: 30%">公開ステータス</td>
+              <td>
+                <%= f.radio_button :is_active, true, checked: true %>
+                <%= label_tag :is_active_true, "有効" %>
+                <%= f.radio_button :is_active, false, class: "ml-3" %>
+                <%= label_tag :is_active_false, "無効" %>
+              </td>
+            </tr>
+          </table>
+          <!--記事変更保存ボタン-->
+          <div class="text-center">
+            <%= f.submit "変更を保存する", class: "mt-2 btn btn-success btn-lg", id: "submit-button"  %>
+          </div>
+        <% end %>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!--「新しくジャンルを作成する」の選択時に発火-->
+<script>
+  // HTMLドキュメントが読み込まれた後に実行される関数
+  $(document).ready(function() {
+    var genreSelect = $("#genre-select");
+    var newGenreForm = $("#new-genre-form");
+    var submitButton = $("#submit-button");
+
+    // ジャンル選択の内容がチェンジされたときに実行する処理
+    genreSelect.on("change", function() {
+      if (genreSelect.val() === "new") {
+        slideDown(newGenreForm);
+        submitButton.prop("disabled", true); // ボタンを無効化する
+      } else {
+        slideUp(newGenreForm);
+        submitButton.prop("disabled", false); // ボタンを有効化する
+      }
+    });
+
+    // 引数で指定された要素をスライドダウンさせ、出現させる処理
+    function slideDown(element) {
+      element.fadeIn(300);
+      $(document).on("click", outsideClick);
+    }
+
+    //引数で指定された要素をスライドアップさせ、引っ込ませる処理
+    function slideUp(element) {
+      element.fadeOut(300);
+    }
+
+    // ポップアップ表示画面外をクリックすることでスライドアップさせる
+    function outsideClick(event) {
+      if (!$(event.target).closest(newGenreForm).length) {
+        slideUp(newGenreForm);
+      }
+    }
+  });
+</script>
+
+<!--画像ファイルが選択された際に発火し、画像のプレビューを表示-->
+<script>
+  $(document).ready(function() {
+    var imagePreview = $("#image-preview");
+    var fileInput = $("#post_image"); //モデル名に基づいて自動で生成されるid
+
+    // 初期状態では非表示に
+    imagePreview.hide();
+
+    // 画像が選択された際に実行される関数
+    fileInput.on("change", function(event) {
+      var file = event.target.files[0];
+
+      // アップロードした画像をセットし、表示する
+      if (file) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          imagePreview.attr("src", e.target.result).show(); // 画像を表示する
+        }
+        reader.readAsDataURL(file);
+      } else {
+        imagePreview.hide(); // 画像が選択されていない場合は非表示にする
+      }
+    });
+  });
+</script>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -95,19 +95,20 @@
     // 引数で指定された要素をスライドダウンさせ、出現させる処理
     function slideDown(element) {
       element.fadeIn(300);
-      $(document).on("click", outsideClick);
+      $(document).on("click", outsideClick); // 表示中は`outsideClick`関数を有効にする
+    }
+
+    // ポップアップ表示画面外をクリックすることでスライドアップさせる
+    function outsideClick(event) {
+      if (!$(event.target).closest(newGenreForm).length) { //「クリックされた要素が内部である場合には数値が返され、それ以外の場合は0となる」の否定形
+        slideUp(newGenreForm);
+      }
     }
 
     //引数で指定された要素をスライドアップさせ、引っ込ませる処理
     function slideUp(element) {
       element.fadeOut(300);
-    }
-
-    // ポップアップ表示画面外をクリックすることでスライドアップさせる
-    function outsideClick(event) {
-      if (!$(event.target).closest(newGenreForm).length) {
-        slideUp(newGenreForm);
-      }
+      $(document).off("click", outsideClick); // 非表示中は`outsideClick`関数を無効にする
     }
   });
 </script>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -94,7 +94,7 @@
 
     // 引数で指定された要素をスライドダウンさせ、出現させる処理
     function slideDown(element) {
-      element.fadeIn(300);
+      element.slideDown(300);
       $(document).on("click", outsideClick); // 表示中は`outsideClick`関数を有効にする
     }
 
@@ -107,7 +107,7 @@
 
     //引数で指定された要素をスライドアップさせ、引っ込ませる処理
     function slideUp(element) {
-      element.fadeOut(300);
+      element.slideUp(300);
       $(document).off("click", outsideClick); // 非表示中は`outsideClick`関数を無効にする
     }
   });

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -14,7 +14,7 @@
             <tr>
               <td>
                 <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
-                  <%= f.text_field :name, placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
+                  <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
                   <%= f.submit "ジャンル作成", class:"col-3 btn btn-primary" %><br>
                   <p class="text-white pt-3"> ※作成をやめる場合は画面外をクリック</p>
                 <% end %>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -7,6 +7,7 @@
            <h5 class="term-title ml-2 font-weight-bold">ニュース管理</h5>
         </div>
 
+        <!--ジャンル管理ボタン-->
         <div class="col-3 mt-3">
           <%= link_to admin_genres_path, class: "py-2 px-3 btn btn-outline-warning" do %>
             <i class="fa-solid fa-tags fa-lg"></i> ジャンル管理

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,2 +1,59 @@
-<h1>Admin::Posts#index</h1>
-<p>Find me in app/views/admin/posts/index.html.erb</p>
+<div class="container my-5">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <div class="row">
+        <div class="col-9">
+           <h5 class="term-title ml-2 font-weight-bold">ニュース管理</h5>
+        </div>
+
+        <!--新規投稿ボタン-->
+        <div class="col-3 mt-3">
+          <%= link_to new_admin_post_path, class: "py-2 px-3 btn btn-primary" do %>
+            <i class="fa-solid fa-folder-plus fa-lg"></i> 新規投稿
+          <% end %>
+        </div>
+      </div>
+
+      <!--各列カラム名-->
+      <table class="table table-colored mt-3">
+        <thead>
+          <tr>
+            <th>記事ID</th>
+            <th>タイトル</th>
+            <th>ステータス</th>
+            <th colspan="2"></th>
+          </tr>
+        </thead>
+
+        <!--記事一覧-->
+        <% @posts.each do |post| %>
+          <tbody>
+            <tr>
+              <td class="align-middle"><%= post.id %></td>
+              <td class="align-middle"><%= post.title %></td>
+              <td class="align-middle">
+                <% if post.is_active %>
+                  <span style="color: green;">有効</span>
+                <% else %>
+                  <span style="color: gray;" >無効</span>
+                <% end %>
+              </td>
+              <td><%= link_to "編集", edit_admin_post_path(post), class: "btn btn-success btn-sm" %></td>
+              <td><%= link_to "削除", admin_post_path(post), class: "btn btn-danger btn-sm", method: :delete, data: {confirm: "削除しますか？"} %></td>
+            </tr>
+          </tbody>
+        <% end %>
+
+      </table>
+
+      <!--ページネーションの設定-->
+      <div class="row">
+        <div class="mt-2 mx-auto">
+          <%= paginate @posts, theme: 'bootstrap-5' %>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -3,12 +3,18 @@
     <div class="offset-1 col-11">
 
       <div class="row">
-        <div class="col-9">
+        <div class="col-3">
            <h5 class="term-title ml-2 font-weight-bold">ニュース管理</h5>
         </div>
 
-        <!--新規投稿ボタン-->
         <div class="col-3 mt-3">
+          <%= link_to admin_genres_path, class: "py-2 px-3 btn btn-outline-warning" do %>
+            <i class="fa-solid fa-tags fa-lg"></i> ジャンル管理
+          <% end %>
+        </div>
+
+        <!--新規投稿ボタン-->
+        <div class="offset-3 col-3 mt-3">
           <%= link_to new_admin_post_path, class: "py-2 px-3 btn btn-primary" do %>
             <i class="fa-solid fa-folder-plus fa-lg"></i> 新規投稿
           <% end %>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -5,7 +5,7 @@
       <!--エラーメッセージ-->
       <%= render 'layouts/errors', obj: @post %>
 
-      <h5 class="term-title ml-2 font-weight-bold">新規ニュース登録</h5>
+      <h5 class="term-title ml-2 font-weight-bold">ニュース登録</h5>
 
       <!--ジャンル新規登録欄（ポップアップ表示）-->
       <div class="col-10 mx-auto form-group" id="new-genre-form"
@@ -25,7 +25,7 @@
 
       <div class="mt-4 form-group">
         <%= form_with model: [:admin, @post], url: admin_posts_path do |f| %>
-          <!--新規単語登録フォーム-->
+          <!--新規記事投稿フォーム-->
           <table class="table table-borderless">
             <tr>
               <td class="align-middle font-weight-bold" style="width: 30%">ジャンル</td>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -1,2 +1,138 @@
-<h1>Admin::Posts#new</h1>
-<p>Find me in app/views/admin/posts/new.html.erb</p>
+<div class="container my-5">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <!--エラーメッセージ-->
+      <%= render 'layouts/errors', obj: @post %>
+
+      <h5 class="term-title ml-2 font-weight-bold">新規ニュース登録</h5>
+
+      <!--ジャンル新規登録欄（ポップアップ表示）-->
+      <div class="col-10 mx-auto form-group" id="new-genre-form"
+           style="display: none; position: absolute; top: 30%; left: 50%; transform: translate(-50%, -50%); background-color: rgba(0, 0, 0, 0.6); padding: 30px; z-index: 99999; border-radius: 10px;">
+        <table class="table table-borderless">
+            <tr>
+              <td>
+                <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
+                  <%= f.text_field :name, placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
+                  <%= f.submit "ジャンル作成", class:"col-3 btn btn-primary" %><br>
+                  <p class="text-white pt-3"> ※作成をやめる場合は画面外をクリック</p>
+                <% end %>
+              </td>
+            </tr>
+        </table>
+      </div>
+
+      <div class="mt-4 form-group">
+        <%= form_with model: [:admin, @post], url: admin_posts_path do |f| %>
+          <!--新規単語登録フォーム-->
+          <table class="table table-borderless">
+            <tr>
+              <td class="align-middle font-weight-bold" style="width: 30%">ジャンル</td>
+              <td>
+                <%= f.select :genre_id, options_for_select([["新しくジャンルを作成する", "new"]].concat(@genres.map { |genre| [genre.name, genre.id] })),
+                  { include_blank: "-- 選択してください --" }, {required: true, class: "form-control", style: "width: 75%;", id: "genre-select" } %>
+              </td>
+            </tr>
+            <tr>
+              <td class="align-middle font-weight-bold" style="width: 30%">タイトル</td>
+              <td><%= f.text_field :title, placeholder: "記事タイトル", class: "form-control"%></td>
+            </tr>
+            <tr>
+              <td class="align-middle font-weight-bold" style="width: 30%">本文</td>
+              <td><%= f.text_area :body, placeholder: "記事本文", class: "form-control", style: "height: 130px;" %></td>
+            </tr>
+            <tr>
+              <td class="align-middle font-weight-bold" style="width: 30%">見出し画像</td>
+              <td>
+                <%= f.file_field :image, accept: "image/png, image/jpeg" %><br>
+                <!--プレビュー表示-->
+                <img class="mt-2" id="image-preview" alt="プレビュー" style="max-width: 150px; border: solid thin lightgray; border-radius: 5px;">
+              </td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold" style="width: 30%">公開ステータス</td>
+              <td>
+                <%= f.radio_button :is_active, true, checked: true %>
+                <%= label_tag :is_active_true, "有効" %>
+                <%= f.radio_button :is_active, false, class: "ml-3" %>
+                <%= label_tag :is_active_false, "無効" %>
+              </td>
+            </tr>
+          </table>
+          <!--新規記事投稿ボタン-->
+          <div class="text-center">
+            <%= f.submit "記事を投稿する", class: "mt-2 btn btn-primary btn-lg", id: "submit-button"  %>
+          </div>
+        <% end %>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!--「新しくジャンルを作成する」の選択時に発火-->
+<script>
+  // HTMLドキュメントが読み込まれた後に実行される関数
+  $(document).ready(function() {
+    var genreSelect = $("#genre-select");
+    var newGenreForm = $("#new-genre-form");
+    var submitButton = $("#submit-button");
+
+    // ジャンル選択の内容がチェンジされたときに実行する処理
+    genreSelect.on("change", function() {
+      if (genreSelect.val() === "new") {
+        slideDown(newGenreForm);
+        submitButton.prop("disabled", true); // ボタンを無効化する
+      } else {
+        slideUp(newGenreForm);
+        submitButton.prop("disabled", false); // ボタンを有効化する
+      }
+    });
+
+    // 引数で指定された要素をスライドダウンさせ、出現させる処理
+    function slideDown(element) {
+      element.fadeIn(300);
+      $(document).on("click", outsideClick);
+    }
+
+    //引数で指定された要素をスライドアップさせ、引っ込ませる処理
+    function slideUp(element) {
+      element.fadeOut(300);
+    }
+
+    // ポップアップ表示画面外をクリックすることでスライドアップさせる
+    function outsideClick(event) {
+      if (!$(event.target).closest(newGenreForm).length) {
+        slideUp(newGenreForm);
+      }
+    }
+  });
+</script>
+
+<!--画像ファイルが選択された際に発火し、画像のプレビューを表示-->
+<script>
+  $(document).ready(function() {
+    var imagePreview = $("#image-preview");
+    var fileInput = $("#post_image"); //モデル名に基づいて自動で生成されるid
+
+    // 初期状態では非表示に
+    imagePreview.hide();
+
+    // 画像が選択された際に実行される関数
+    fileInput.on("change", function(event) {
+      var file = event.target.files[0];
+
+      // アップロードした画像をセットし、表示する
+      if (file) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          imagePreview.attr("src", e.target.result).show(); // 画像を表示する
+        }
+        reader.readAsDataURL(file);
+      } else {
+        imagePreview.hide(); // 画像が選択されていない場合は非表示にする
+      }
+    });
+  });
+</script>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -93,19 +93,20 @@
     // 引数で指定された要素をスライドダウンさせ、出現させる処理
     function slideDown(element) {
       element.fadeIn(300);
-      $(document).on("click", outsideClick);
+      $(document).on("click", outsideClick); // 表示中は`outsideClick`関数を有効にする
+    }
+
+    // ポップアップ表示画面外をクリックすることでスライドアップさせる
+    function outsideClick(event) {
+      if (!$(event.target).closest(newGenreForm).length) { //「クリックされた要素が内部である場合には数値が返され、それ以外の場合は0となる」の否定形
+        slideUp(newGenreForm);
+      }
     }
 
     //引数で指定された要素をスライドアップさせ、引っ込ませる処理
     function slideUp(element) {
       element.fadeOut(300);
-    }
-
-    // ポップアップ表示画面外をクリックすることでスライドアップさせる
-    function outsideClick(event) {
-      if (!$(event.target).closest(newGenreForm).length) {
-        slideUp(newGenreForm);
-      }
+      $(document).off("click", outsideClick); // 非表示中は`outsideClick`関数を無効にする
     }
   });
 </script>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -92,7 +92,7 @@
 
     // 引数で指定された要素をスライドダウンさせ、出現させる処理
     function slideDown(element) {
-      element.fadeIn(300);
+      element.slideDown(300);
       $(document).on("click", outsideClick); // 表示中は`outsideClick`関数を有効にする
     }
 
@@ -105,7 +105,7 @@
 
     //引数で指定された要素をスライドアップさせ、引っ込ませる処理
     function slideUp(element) {
-      element.fadeOut(300);
+      element.slideUp(300);
       $(document).off("click", outsideClick); // 非表示中は`outsideClick`関数を無効にする
     }
   });

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -14,7 +14,7 @@
             <tr>
               <td>
                 <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
-                  <%= f.text_field :name, placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
+                  <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
                   <%= f.submit "ジャンル作成", class:"col-3 btn btn-primary" %><br>
                   <p class="text-white pt-3"> ※作成をやめる場合は画面外をクリック</p>
                 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
 
     resources :today_words, only: [:new, :create, :index, :edit, :update, :destroy]
 
-    resources :genres, only: [:create, :index, :edit, :update, :destroy]
+    resources :genres, only: [:create, :index, :update]
 
     resources :posts, only: [:new, :create, :index, :edit, :update, :destroy]
 


### PR DESCRIPTION
以下の変更点を含みます。

### ニュース管理一覧画面(:index)作成
テーブルには記事ID、タイトル、ステータス、編集/削除リンクを含む他、  
テーブル上部にはジャンル管理一覧リンクとニュース記事作成リンクのボタンを配置しました。

### ニュース記事作成画面(:new, :edit)、及び機能作成
レコードの作成機能以外に関して、特筆すべき点は以下になります。
- ジャンルプルダウンメニューより「新しくジャンルを作成」を選択した場合、作成画面ポップアップが表示
- また、上記の項目が選択されている間は、「記事を投稿する」「変更を保存する」ボタンが無効化
- 見出し画像を選択した際のプレビュー機能を追加

### ジャンル管理一覧画面(:index)、及び編集機能作成
ジャンルの一覧表示以外に関して、特筆すべき点は以下になります。
- テーブル上部のジャンル作成を押下した際、記事作成画面と同じ作成画面ポップアップが表示
- 各レコードの編集ボタン押下時、編集ボタンが保存ボタンに切り替わり、テーブル内でジャンル名の編集が可能に
- ジャンルの作成数は後述の通り最大13項目に限定しているため、ページネーションは未実装

### 作成可能なジャンルの数を最大13項目に設定
homes/top画面のレイアウトを保つという観点から、作成可能なジャンルの数を最大13項目に設定しました。

### admin/genresコントローラ内の:edit, :destroyの記述、及びルーティングを削除
使用しなかったため。