### PR TITLE
[Update] ニュース関連画面のレイアウト・機能作成

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,7 +1,7 @@
 class Public::HomesController < Public::ApplicationController
 
   def top
-    @posts = Post.where(is_active: true).order(id: "DESC").limit(4)
+    @posts = Post.where(is_active: true).page(params[:page]).order(id: "DESC").per(4)
     @genres = Genre.all
     @questions = Question.all.order(id: "DESC").limit(3)
   end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -15,7 +15,7 @@ class Public::PostsController < Public::ApplicationController
     @next_post = Post.where("id > ? AND is_active = ?", @post, true).order(:id).first
 
     if @post.nil? || !@post.is_active
-      redirect_to posts_path, alert: "単語が見つかりません。"
+      redirect_to posts_path, alert: "記事が見つかりません。"
     end
   end
 

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -1,9 +1,22 @@
 class Public::PostsController < Public::ApplicationController
-  
+
   def index
+    if params[:genre_id]
+      @genre = Genre.find(params[:genre_id])
+      @posts = Post.where(genre_id: params[:genre_id], is_active: true).page(params[:page]).order(id: "DESC").limit(8)
+    else
+      @posts = Post.where(is_active: true).page(params[:page]).order(id: "DESC").limit(8)
+    end
   end
 
   def show
+    @post = Post.find_by(id: params[:id])
+    @previous_post = Post.where("id < ? AND is_active = ?", @post, true).order(id: "DESC").first
+    @next_post = Post.where("id > ? AND is_active = ?", @post, true).order(:id).first
+
+    if @post.nil? || !@post.is_active
+      redirect_to posts_path, alert: "単語が見つかりません。"
+    end
   end
-  
+
 end

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -19,6 +19,12 @@
   }
 }
 
+.index-news{
+  border-radius: 10px;
+  height: 380px;
+  background-color: white;
+}
+
 .question{
   border-radius: 10px;
   width: 90%;

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -41,9 +41,12 @@
           <% end %>
         </div>
 
-        <p class="border border-dark text-center ml-3 mt-2 pt-2" style="font-size: 30px; height: 65px; width: 95%">
-          <%= link_to "もっとみる", posts_path, class: "text-dark" %>
-        </p>
+        <!--ページネーションの設定-->
+        <div class="row">
+          <div class="mt-2 mx-auto">
+            <%= paginate @posts, theme: 'bootstrap-5' %>
+          </div>
+        </div>
 
       </div>
     </div>

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -1,2 +1,46 @@
-<h1>Public::Posts#index</h1>
-<p>Find me in app/views/public/posts/index.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <h3 class="pt-5 ml-5 font-weight-bold">ニュース一覧</h3>
+
+      <div class="content-box mt-4">
+        <!--1つの行に2記事を表示する-->
+        <div class="row mx-auto w-100">
+          <% @posts.each do |post| %>
+            <!--１記事-->
+            <div class="col-6">
+              <%= link_to post_path(post.id) do %>
+                <div class="index-news border my-3">
+                  <div class="my-3 ml-3">
+                    <%= image_tag post.get_image(280, 190), style: "border-radius: 10px;" %>
+                  </div>
+                  <div class="my-2 mx-3 border text-center text-dark" style="width: 45%; font-size: 14px">
+                    <%= post.genre.name %>
+                  </div>
+                  <div class="ml-3 mr-2 font-weight-bold text-dark">
+                    <%= truncate(post.title, length: 48, omission: '...') %>
+                  </div>
+                  <div class="m-3 text-dark" style="font-size: 12px; position: absolute; bottom: 3%;">
+                    <i class="far fa-clock"></i>
+                    <%= post.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+
+          <% end %>
+        </div>
+
+        <!--ページネーションの設定-->
+        <div class="row">
+          <div class="mt-2 mx-auto">
+            <%= paginate @posts, theme: 'bootstrap-5' %>
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -1,2 +1,50 @@
-<h1>Public::Posts#show</h1>
-<p>Find me in app/views/public/posts/show.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="offset-1 col-11">
+      <div class="content-box word_card" style="margin-top: 100px">
+
+        <!--記事タイトル-->
+        <div class="my-3">
+          <div class="my-2 mx-3 border text-center text-dark" style="width: 23%; font-size: 18px">
+            <%= link_to @post.genre.name, posts_path(genre_id: @post.genre_id), class: "text-dark" %>
+          </div>
+          <div class="m-3 font-weight-bold" style="font-size: 26px">
+            <%= @post.title %>
+          </div>
+          <div class="m-3 text-dark text-right" style="font-size: 14px;">
+            <i class="far fa-clock"></i>
+            <%= @post.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
+          </div>
+        </div>
+
+
+        <!--記事見出し-->
+        <div><%= image_tag @post.get_image(685, 466) %></div>
+
+        <!--記事本文-->
+        <div class="my-4 p-3" style="font-size: 18px;">
+          <%= @post.body %>
+        </div>
+
+      </div>
+
+      <div class="row my-4 pl-4 mx-auto">
+        <div class="col-3">
+          <% if @previous_post %>
+            <%= link_to post_path(@previous_post), class: "btn btn-primary" do %>
+              <i class="fa-solid fa-left-long"></i> 前の記事へ
+            <% end %>
+          <% end %>
+        </div>
+        <div class="offset-6 col-3">
+          <% if @next_post %>
+            <%= link_to post_path(@next_post), class: "btn btn-primary" do %>
+              次の記事へ <i class="fa-solid fa-right-long"></i>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
以下の変更点を含みます。

### TOPページのニュース欄にページネーションを追加
非同期通信化は未対応です。

### ニュース関連画面のレイアウト・機能作成
- 一覧画面(:index)のレイアウト
- 詳細画面(:show)のレイアウト
- コントローラへの記述
- 詳細画面内の次の記事/前の記事ボタンの押下時、記事が無効、もしくは存在しない場合にスキップする処理を追加
- 無効対象/存在しない記事にURL入力で直接遷移した場合、一覧画面に戻す処理を追加
- TOPページ内ニュース欄隣のジャンル名、または詳細画面内のジャンル名押下で、ジャンル別の一覧画面に遷移
