### PR TITLE
[Update] public/questions関連画面・機能の作成、サイトデザイン変更

### DIFF
--- a/app/controllers/public/answers_controller.rb
+++ b/app/controllers/public/answers_controller.rb
@@ -5,10 +5,7 @@ class Public::AnswersController < Public::ApplicationController
     answer = Answer.new(answer_params)
     answer.user_id = current_user.id
     answer.question_id = question.id
-    if question.user == current_user
-      redirect_to request.referer
-      flash[:alert] = "自身の質問には回答できません。"
-    elsif answer.save
+    if answer.save
       redirect_to question_path(question)
     else
       @question = question

--- a/app/controllers/public/answers_controller.rb
+++ b/app/controllers/public/answers_controller.rb
@@ -1,6 +1,26 @@
 class Public::AnswersController < Public::ApplicationController
-  
+
   def create
+    question = Question.find(params[:question_id])
+    answer = Answer.new(answer_params)
+    answer.user_id = current_user.id
+    answer.question_id = question.id
+    if question.user == current_user
+      redirect_to request.referer
+      flash[:alert] = "自身の質問には回答できません。"
+    elsif answer.save
+      redirect_to question_path(question)
+    else
+      @question = question
+      @answer = answer
+      render 'public/questions/show'
+    end
   end
-  
+
+  private
+
+  def answer_params
+    params.require(:answer).permit(:body)
+  end
+
 end

--- a/app/controllers/public/bookmarks_controller.rb
+++ b/app/controllers/public/bookmarks_controller.rb
@@ -1,12 +1,21 @@
 class Public::BookmarksController < Public::ApplicationController
 
   def create
+    question = Question.find(params[:question_id])
+    bookmark = question.bookmarks.new(user_id: current_user.id)
+    bookmark.save
+    redirect_to request.referer
   end
 
   def index
+    @bookmarks = current_user.bookmarks.page(params[:page]).order(id: "DESC").per(10)
   end
 
   def destroy
+    question = Question.find(params[:question_id])
+    bookmark = question.bookmarks.find_by(user_id: current_user.id)
+    bookmark.destroy
+    redirect_to request.referer
   end
 
 end

--- a/app/controllers/public/evaluations_controller.rb
+++ b/app/controllers/public/evaluations_controller.rb
@@ -1,9 +1,21 @@
 class Public::EvaluationsController < Public::ApplicationController
-  
+
   def create
+    answer = Answer.find(params[:answer_id])
+    evaluation = answer.evaluations.new(user_id: current_user.id)
+    if answer.user == current_user
+      flash[:alert] = "自分の回答に評価をつけることはできません。"
+      redirect_to request.referer
+    else evaluation.save
+      redirect_to request.referer
+    end
   end
-  
+
   def destroy
+    answer = Answer.find(params[:answer_id])
+    evaluation = answer.evaluations.find_by(user_id: current_user.id)
+    evaluation.destroy
+    redirect_to request.referer
   end
-  
+
 end

--- a/app/controllers/public/questions_controller.rb
+++ b/app/controllers/public/questions_controller.rb
@@ -5,13 +5,16 @@ class Public::QuestionsController < Public::ApplicationController
 
   def create
   end
+  
+  ORDER_BY_POPULAR = 'popular'
+  ORDER_BY_NEW = 'new'
 
   def index
-    if params[:order] == "popular"
-      @order = "popular"
+    if params[:order] == ORDER_BY_POPULAR
+      @order = ORDER_BY_POPULAR
       @questions = Question.all.page(params[:page]).order(views_count: "DESC").per(10)
     else
-      @order = "new"
+      @order = ORDER_BY_NEW
       @questions = Question.all.page(params[:page]).order(id: "DESC").per(10)
     end
   end

--- a/app/controllers/public/questions_controller.rb
+++ b/app/controllers/public/questions_controller.rb
@@ -7,9 +7,18 @@ class Public::QuestionsController < Public::ApplicationController
   end
 
   def index
+    if params[:order] == "popular"
+      @order = "popular"
+      @questions = Question.all.page(params[:page]).order(views_count: "DESC").per(10)
+    else
+      @order = "new"
+      @questions = Question.all.page(params[:page]).order(id: "DESC").per(10)
+    end
   end
 
   def show
+    @question = Question.find(params[:id])
+    @question.increment_views_count!
   end
 
 end

--- a/app/controllers/public/questions_controller.rb
+++ b/app/controllers/public/questions_controller.rb
@@ -1,11 +1,19 @@
 class Public::QuestionsController < Public::ApplicationController
 
   def new
+    @question = Question.new
   end
 
   def create
+    @question = Question.new(question_params)
+    @question.user_id = current_user.id
+    if @question.save
+      redirect_to question_path(@question)
+    else
+      render :new
+    end
   end
-  
+
   ORDER_BY_POPULAR = 'popular'
   ORDER_BY_NEW = 'new'
 
@@ -22,6 +30,12 @@ class Public::QuestionsController < Public::ApplicationController
   def show
     @question = Question.find(params[:id])
     @question.increment_views_count!
+  end
+
+  private
+
+  def question_params
+    params.require(:question).permit(:title, :body)
   end
 
 end

--- a/app/controllers/public/questions_controller.rb
+++ b/app/controllers/public/questions_controller.rb
@@ -28,9 +28,16 @@ class Public::QuestionsController < Public::ApplicationController
   end
 
   def show
-    @question = Question.find(params[:id])
+    @question = Question.find_by(id: params[:id])
     @question.increment_views_count!
     @answer = Answer.new
+
+    @previous_question = Question.where("id < ?", @question).order(id: "DESC").first
+    @next_question = Question.where("id > ?", @question).order(:id).first
+
+    if @question.nil?
+      redirect_to questions_path, alert: "質問が見つかりません。"
+    end
   end
 
   private

--- a/app/controllers/public/questions_controller.rb
+++ b/app/controllers/public/questions_controller.rb
@@ -30,6 +30,7 @@ class Public::QuestionsController < Public::ApplicationController
   def show
     @question = Question.find(params[:id])
     @question.increment_views_count!
+    @answer = Answer.new
   end
 
   private

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -1,3 +1,8 @@
+body{
+  background: linear-gradient(to bottom right, #8bc5ec, #f0aa8f);
+  font-family: 'RocknRoll One', sans-serif;
+}
+
 .content-box{
   background-color: rgba(255, 255, 255, 0.5);
   padding: 20px;

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -46,6 +46,12 @@ body{
     margin-bottom: 1rem;
     width: 95%;
   }
+  a {
+    text-decoration: none !important;
+  }
+  a:hover {
+    color: #ff8c00;
+  }
 }
 
 .word_card{

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -65,7 +65,7 @@ body{
   }
 }
 
-.profile-image {
+.delete-underline {
   a {
     text-decoration: none !important;
   }

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -64,3 +64,9 @@ body{
   background-color: white;
   }
 }
+
+.profile-image {
+  a {
+    text-decoration: none !important;
+  }
+}

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -3,6 +3,10 @@ body{
   font-family: 'RocknRoll One', sans-serif;
 }
 
+.main{
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+}
+
 .content-box{
   background-color: rgba(255, 255, 255, 0.5);
   padding: 20px;

--- a/app/javascript/stylesheets/header.scss
+++ b/app/javascript/stylesheets/header.scss
@@ -10,3 +10,7 @@
     width: 85%;
   }
 }
+
+.text-color {
+  color: #066285;
+}

--- a/app/javascript/stylesheets/header.scss
+++ b/app/javascript/stylesheets/header.scss
@@ -9,6 +9,12 @@
     margin-bottom: 2rem;
     width: 85%;
   }
+  a {
+    text-decoration: none !important;
+  }
+  a:hover {
+    color: #066285;
+  }
 }
 
 .text-color {

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,9 +1,9 @@
 class Answer < ApplicationRecord
-  
+
   belongs_to :user
   belongs_to :question
   has_many :evaluations, dependent: :destroy
 
-  validates :body, presence: true, length: { maximum: 100 }
+  validates :body, presence: true, length: { maximum: 300 }
 
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -6,4 +6,8 @@ class Answer < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: 300 }
 
+  def evaluated_by?(user)
+    evaluations.exists?(user_id: user.id)
+  end
+
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -3,6 +3,4 @@ class Evaluation < ApplicationRecord
   belongs_to :user
   belongs_to :answer
 
-  enum status: { good: 0, bad: 1 }
-
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,10 +1,14 @@
 class Question < ApplicationRecord
-  
+
   belongs_to :user
   has_many :answers, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :body,  presence: true, length: { maximum: 300 }
+
+  def bookmarked_by?(user)
+    bookmarks.exists?(user_id: user.id)
+  end
 
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,4 +11,8 @@ class Question < ApplicationRecord
     bookmarks.exists?(user_id: user.id)
   end
 
+  def increment_views_count!
+    increment!(:views_count)
+  end
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <script src="https://kit.fontawesome.com/0fa15b6b25.js" crossorigin="anonymous"></script>
     <link href="https://fonts.googleapis.com/css2?family=RocknRoll+One&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500&display=swap" rel="stylesheet">
 
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
@@ -67,7 +68,7 @@
 
         </div>
 
-        <div class="col-9">
+        <div class="main col-9">
           <!--フラッシュメッセージ-->
           <%= render 'layouts/flash' %>
           <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,33 +26,93 @@
           <% if user_signed_in? %>
             <!--会員側ログイン時-->
             <div class="menu h4">
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "今日の中国語", today_words_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ニュース", posts_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "質問板", questions_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "マイページ", user_path(current_user), class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ログアウト", destroy_user_session_path, class: "text-color", method: :delete %></p><hr>
+              <p>
+                <%= link_to today_words_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> 今日の中国語
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to posts_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> ニュース
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to questions_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> 質問板
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to user_path(current_user), class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> マイページ
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to destroy_user_session_path, class: "text-color", method: :delete do %>
+                  <i class="fa-solid fa-pencil text-color"></i> ログアウト
+                <% end %>
+              </p><hr>
             </div>
           <% elsif admin_signed_in? %>
             <!--管理側ログイン時-->
             <div class="menu h4">
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "中国語管理", admin_today_words_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ニュース管理", admin_posts_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "質問板管理", admin_questions_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "会員管理", admin_users_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ログアウト", destroy_admin_session_path, class: "text-color", method: :delete %></p><hr>
+              <p>
+                <%= link_to admin_today_words_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> 中国語管理
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to admin_posts_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> ニュース管理
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to admin_questions_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> 質問板管理
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to admin_users_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> 会員管理
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to destroy_admin_session_path, class: "text-color", method: :delete do %>
+                  <i class="fa-solid fa-pencil text-color"></i> ログアウト
+                <% end %>
+              </p><hr>
             </div>
           <% else %>
             <!--未ログイン時-->
             <div class="menu h4">
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "今日の中国語", today_words_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ニュース", posts_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "質問板", questions_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ログイン", new_user_session_path, class: "text-color" %></p><hr>
-              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "新規登録", new_user_registration_path, class: "text-color" %></p><hr>
+              <p>
+                <%= link_to today_words_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> 今日の中国語
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to posts_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> ニュース
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to questions_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> 質問板
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to new_user_session_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> ログイン
+                <% end %>
+              </p><hr>
+              <p>
+                <%= link_to new_user_registration_path, class: "text-color" do %>
+                  <i class="fa-solid fa-pencil text-color"></i> 新規登録
+                <% end %>
+              </p><hr>
             </div>
           <% end %>
 
-          <div class="social h1">
+          <div class="menu h1">
             <%= link_to "https://twitter.com", class: "mx-2" do %>
               <i class="fa-brands fa-twitter text-color"></i>
             <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
 
     <script src="https://kit.fontawesome.com/0fa15b6b25.js" crossorigin="anonymous"></script>
+    <link href="https://fonts.googleapis.com/css2?family=RocknRoll+One&display=swap" rel="stylesheet">
 
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
@@ -16,7 +17,7 @@
     <div class="container">
       <div class="row">
 
-        <div class="col-3 fixed-sidebar text-center" style="background-color: #FFDC44; height: 100%;">
+        <div class="col-3 fixed-sidebar text-center" style="background-color: #fccc4a; height: 100%;">
           <p class="border border-dark p-5 my-5" style="font-size: 50px;">
             <%= link_to "LOGO", root_path, class: "text-dark" %>
           </p>
@@ -24,45 +25,45 @@
           <% if user_signed_in? %>
             <!--会員側ログイン時-->
             <div class="menu h4">
-              <p><%= link_to "今日の中国語", today_words_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "ニュース", posts_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "質問板", questions_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "マイページ", user_path(current_user), class: "text-dark" %></p><hr>
-              <p><%= link_to "ログアウト", destroy_user_session_path, class: "text-dark", method: :delete %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "今日の中国語", today_words_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ニュース", posts_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "質問板", questions_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "マイページ", user_path(current_user), class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ログアウト", destroy_user_session_path, class: "text-color", method: :delete %></p><hr>
             </div>
           <% elsif admin_signed_in? %>
             <!--管理側ログイン時-->
             <div class="menu h4">
-              <p><%= link_to "中国語管理", admin_today_words_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "ニュース管理", admin_posts_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "質問板管理", admin_questions_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "会員管理", admin_users_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "ログアウト", destroy_admin_session_path, class: "text-dark", method: :delete %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "中国語管理", admin_today_words_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ニュース管理", admin_posts_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "質問板管理", admin_questions_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "会員管理", admin_users_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ログアウト", destroy_admin_session_path, class: "text-color", method: :delete %></p><hr>
             </div>
           <% else %>
             <!--未ログイン時-->
             <div class="menu h4">
-              <p><%= link_to "今日の中国語", today_words_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "ニュース", posts_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "質問板", questions_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "ログイン", new_user_session_path, class: "text-dark" %></p><hr>
-              <p><%= link_to "新規登録", new_user_registration_path, class: "text-dark" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "今日の中国語", today_words_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ニュース", posts_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "質問板", questions_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "ログイン", new_user_session_path, class: "text-color" %></p><hr>
+              <p><i class="fa-solid fa-pencil text-color"></i> <%= link_to "新規登録", new_user_registration_path, class: "text-color" %></p><hr>
             </div>
           <% end %>
 
           <div class="social h1">
             <%= link_to "https://twitter.com", class: "mx-2" do %>
-              <i class="fa-brands fa-twitter" style="color: #000000;"></i>
+              <i class="fa-brands fa-twitter text-color"></i>
             <% end %>
             <%= link_to "https://instagram.com/", class: "mx-2" do %>
-              <i class="fa-brands fa-instagram" style="color: #000000;"></i>
+              <i class="fa-brands fa-instagram text-color"></i>
             <% end %>
             <%= link_to "https://tiktok.com/", class: "mx-2" do %>
-              <i class="fa-brands fa-tiktok" style="color: #000000;"></i>
+              <i class="fa-brands fa-tiktok text-color"></i>
             <% end %>
           </div>
 
-          <p>copyright</p>
+          <p class="text-color">copyright</p>
 
         </div>
 

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -118,7 +118,7 @@
                       <i class="fa-solid fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
                     <% end %>
                   <% else %>
-                    <%= link_to question_bookmarks_path(question, question_id: question.id), method: :post do %>
+                    <%= link_to question_bookmarks_path(question), method: :post do %>
                       <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
                     <% end %>
                   <% end %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -131,6 +131,7 @@
                 <% end %>
                 <span class="ml-1" style="font-size: 16px;"><%= question.bookmarks.count %></span>
                 <i class="fas fa-eye ml-4 pt-1"  style="font-size: 20px;"></i>
+                <span class="ml-1" style="font-size: 16px;"><%= question.views_count %></span>
               </div>
             </div>
           </div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -125,7 +125,6 @@
                 <% else %>
                   <!--ユーザーが未ログインの場合はログインページに遷移する-->
                   <%= link_to new_user_session_path do %>
-                    <% flash[:alert] = "ブックマーク機能のご利用にはログインが必要です。" %>
                     <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
                   <% end %>
                 <% end %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -111,7 +111,24 @@
               </div>
               <!--ブックマーク・閲覧数-->
               <div class="offset-1 col-3">
-                <i class="far fa-bookmark" style="font-size: 20px;"></i>
+                <!--ブックマークボタン-->
+                <% if current_user %>
+                  <% if question.bookmarked_by?(current_user) %>
+                    <%= link_to question_bookmark_path(question, question_id: question.id), method: :delete do %>
+                      <i class="fa-solid fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                    <% end %>
+                  <% else %>
+                    <%= link_to question_bookmarks_path(question, question_id: question.id), method: :post do %>
+                      <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                    <% end %>
+                  <% end %>
+                <% else %>
+                  <!--ユーザーが未ログインの場合はログインページに遷移する-->
+                  <%= link_to new_user_session_path do %>
+                    <% flash[:alert] = "ブックマーク機能のご利用にはログインが必要です。" %>
+                    <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                  <% end %>
+                <% end %>
                 <span class="ml-1" style="font-size: 16px;"><%= question.bookmarks.count %></span>
                 <i class="fas fa-eye ml-4 pt-1"  style="font-size: 20px;"></i>
               </div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -110,7 +110,7 @@
                 <b class="ml-1"><%= question.answers.count %>人が回答済み</b>
               </div>
               <!--ブックマーク・閲覧数-->
-              <div class="offset-1 col-3">
+              <div class="col-4 pl-5 mt-2">
                 <!--ブックマークボタン-->
                 <% if current_user %>
                   <% if question.bookmarked_by?(current_user) %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="offset-1 col-11">
       <%= link_to today_words_path do %>
-        <div class="mt-4 mx-auto p-4" style="background-color: orange; width: 90%; height: 300px;"></div>
+        <div class="mt-4 mx-auto p-4" style="background-color: white; width: 90%; height: 300px;"></div>
       <% end %>
     </div>
   </div>

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -32,13 +32,13 @@
           <% end %>
         </div>
 
-        <!--ページネーションの設定-->
-        <div class="row">
-          <div class="mt-2 mx-auto">
-            <%= paginate @posts, theme: 'bootstrap-5' %>
-          </div>
+      </div>
+      
+      <!--ページネーションの設定-->
+      <div class="row">
+        <div class="mt-4 mx-auto">
+          <%= paginate @posts, theme: 'bootstrap-5' %>
         </div>
-
       </div>
 
     </div>

--- a/app/views/public/questions/index.html.erb
+++ b/app/views/public/questions/index.html.erb
@@ -21,15 +21,15 @@
 
       <ul class="nav nav-tabs mt-4">
         <li class="nav-item">
-          <%= link_to "新着順", questions_path, class: "nav-link #{new_tab_active}" %>
+          <%= link_to "新着順", questions_path, class: "nav-link text-color #{new_tab_active}" %>
         </li>
         <li class="nav-item">
-          <%= link_to "人気順", questions_path(order: Public::QuestionsController::ORDER_BY_POPULAR), class: "nav-link #{popular_tab_active}" %>
+          <%= link_to "人気順", questions_path(order: Public::QuestionsController::ORDER_BY_POPULAR), class: "nav-link text-color #{popular_tab_active}" %>
         </li>
       </ul>
 
       <div class="content-box">
-        
+
         <!--1質問-->
         <% @questions.each do |question| %>
           <div class="question mt-3 border mx-auto">

--- a/app/views/public/questions/index.html.erb
+++ b/app/views/public/questions/index.html.erb
@@ -29,64 +29,64 @@
       </ul>
 
       <div class="content-box">
-
-          <!--1質問-->
-          <% @questions.each do |question| %>
-            <div class="question mt-3 border mx-auto">
-              <div class="question-title m-3">
-                <%= link_to truncate(question.title, length: 34, omission: '...'), question_path(question) %>
-              </div>
-              <hr>
-              <!--回答者情報-->
-              <div class="row m-3">
-                <div class="col-8">
-                  <!--回答者のプロフィール画像を3つまで取り出す-->
-                  <% count = 0 %>
-                  <% question.answers.each do |answer| %>
-                    <% if count < 3 %>
-                      <%= image_tag answer.user.get_profile_image(35, 35), class: "rounded-circle" %>
-                      <% count += 1 %>
-                    <% else %>
-                      <% break %>
-                    <% end %>
+        
+        <!--1質問-->
+        <% @questions.each do |question| %>
+          <div class="question mt-3 border mx-auto">
+            <div class="question-title m-3">
+              <%= link_to truncate(question.title, length: 34, omission: '...'), question_path(question) %>
+            </div>
+            <hr>
+            <!--回答者情報-->
+            <div class="row m-3">
+              <div class="col-8">
+                <!--回答者のプロフィール画像を3つまで取り出す-->
+                <% count = 0 %>
+                <% question.answers.each do |answer| %>
+                  <% if count < 3 %>
+                    <%= image_tag answer.user.get_profile_image(35, 35), class: "rounded-circle" %>
+                    <% count += 1 %>
+                  <% else %>
+                    <% break %>
                   <% end %>
-                  <b class="ml-1"><%= question.answers.count %>人が回答済み</b>
-                </div>
-                <!--ブックマーク・閲覧数-->
-                <div class="offset-1 col-3">
-                  <!--ブックマークボタン-->
-                  <% if current_user %>
-                    <% if question.bookmarked_by?(current_user) %>
-                      <%= link_to question_bookmark_path(question, question_id: question.id), method: :delete do %>
-                        <i class="fa-solid fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
-                      <% end %>
-                    <% else %>
-                      <%= link_to question_bookmarks_path(question, question_id: question.id), method: :post do %>
-                        <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
-                      <% end %>
+                <% end %>
+                <b class="ml-1"><%= question.answers.count %>人が回答済み</b>
+              </div>
+              <!--ブックマーク・閲覧数-->
+              <div class="offset-1 col-3">
+                <!--ブックマークボタン-->
+                <% if current_user %>
+                  <% if question.bookmarked_by?(current_user) %>
+                    <%= link_to question_bookmark_path(question, question_id: question.id), method: :delete do %>
+                      <i class="fa-solid fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
                     <% end %>
                   <% else %>
-                    <!--ユーザーが未ログインの場合はログインページに遷移する-->
-                    <%= link_to new_user_session_path do %>
+                    <%= link_to question_bookmarks_path(question, question_id: question.id), method: :post do %>
                       <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
                     <% end %>
                   <% end %>
-                  <span class="ml-1" style="font-size: 16px;"><%= question.bookmarks.count %></span>
-                  <i class="fas fa-eye ml-4 pt-1"  style="font-size: 20px;"></i>
-                  <span class="ml-1" style="font-size: 16px;"><%= question.views_count %></span>
-                </div>
+                <% else %>
+                  <!--ユーザーが未ログインの場合はログインページに遷移する-->
+                  <%= link_to new_user_session_path do %>
+                    <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                  <% end %>
+                <% end %>
+                <span class="ml-1" style="font-size: 16px;"><%= question.bookmarks.count %></span>
+                <i class="fas fa-eye ml-4 pt-1"  style="font-size: 20px;"></i>
+                <span class="ml-1" style="font-size: 16px;"><%= question.views_count %></span>
               </div>
             </div>
-          <% end %>
-
-        </div>
-
-        <!--ページネーションの設定-->
-        <div class="row">
-          <div class="mt-4 mx-auto">
-            <%= paginate @questions, theme: 'bootstrap-5' %>
           </div>
+        <% end %>
+
+      </div>
+
+      <!--ページネーションの設定-->
+      <div class="row">
+        <div class="mt-4 mx-auto">
+          <%= paginate @questions, theme: 'bootstrap-5' %>
         </div>
+      </div>
 
     </div>
   </div>

--- a/app/views/public/questions/index.html.erb
+++ b/app/views/public/questions/index.html.erb
@@ -16,15 +16,15 @@
       </div>
 
       <!--ソートタブ-->
-      <% new_tab_active = 'active' if @order == "new" %>
-      <% popular_tab_active = 'active' if @order == "popular" %>
+      <% new_tab_active = 'active' if @order == Public::QuestionsController::ORDER_BY_NEW %>
+      <% popular_tab_active = 'active' if @order == Public::QuestionsController::ORDER_BY_POPULAR %>
 
       <ul class="nav nav-tabs mt-4">
         <li class="nav-item">
           <%= link_to "新着順", questions_path, class: "nav-link #{new_tab_active}" %>
         </li>
         <li class="nav-item">
-          <%= link_to "人気順", questions_path(order: "popular"), class: "nav-link #{popular_tab_active}" %>
+          <%= link_to "人気順", questions_path(order: Public::QuestionsController::ORDER_BY_POPULAR), class: "nav-link #{popular_tab_active}" %>
         </li>
       </ul>
 

--- a/app/views/public/questions/index.html.erb
+++ b/app/views/public/questions/index.html.erb
@@ -53,7 +53,7 @@
                 <b class="ml-1"><%= question.answers.count %>人が回答済み</b>
               </div>
               <!--ブックマーク・閲覧数-->
-              <div class="offset-1 col-3">
+              <div class="col-4 pl-5 mt-2">
                 <!--ブックマークボタン-->
                 <% if current_user %>
                   <% if question.bookmarked_by?(current_user) %>

--- a/app/views/public/questions/index.html.erb
+++ b/app/views/public/questions/index.html.erb
@@ -1,2 +1,93 @@
-<h1>Public::Questions#index</h1>
-<p>Find me in app/views/public/questions/index.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <div class="row pt-5 pl-5">
+        <div class="col-3 h3 font-weight-bold">質問板</div>
+        <!--検索欄-->
+        <div class="col-6 input-group">
+          <input class="form-control" placeholder="質問を検索">
+          <button class="btn btn-outline-success", style="height: 92%;"><i class="fas fa-search"></i> 検索</button>
+        </div>
+        <!--質問するボタン-->
+        <div class="col-3">
+          <%= link_to "質問する", new_question_path, class: "btn btn-primary" %>
+        </div>
+      </div>
+
+      <!--ソートタブ-->
+      <% new_tab_active = 'active' if @order == "new" %>
+      <% popular_tab_active = 'active' if @order == "popular" %>
+
+      <ul class="nav nav-tabs mt-4">
+        <li class="nav-item">
+          <%= link_to "新着順", questions_path, class: "nav-link #{new_tab_active}" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "人気順", questions_path(order: "popular"), class: "nav-link #{popular_tab_active}" %>
+        </li>
+      </ul>
+
+      <div class="content-box">
+
+          <!--1質問-->
+          <% @questions.each do |question| %>
+            <div class="question mt-3 border mx-auto">
+              <div class="question-title m-3">
+                <%= link_to truncate(question.title, length: 34, omission: '...'), question_path(question) %>
+              </div>
+              <hr>
+              <!--回答者情報-->
+              <div class="row m-3">
+                <div class="col-8">
+                  <!--回答者のプロフィール画像を3つまで取り出す-->
+                  <% count = 0 %>
+                  <% question.answers.each do |answer| %>
+                    <% if count < 3 %>
+                      <%= image_tag answer.user.get_profile_image(35, 35), class: "rounded-circle" %>
+                      <% count += 1 %>
+                    <% else %>
+                      <% break %>
+                    <% end %>
+                  <% end %>
+                  <b class="ml-1"><%= question.answers.count %>人が回答済み</b>
+                </div>
+                <!--ブックマーク・閲覧数-->
+                <div class="offset-1 col-3">
+                  <!--ブックマークボタン-->
+                  <% if current_user %>
+                    <% if question.bookmarked_by?(current_user) %>
+                      <%= link_to question_bookmark_path(question, question_id: question.id), method: :delete do %>
+                        <i class="fa-solid fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                      <% end %>
+                    <% else %>
+                      <%= link_to question_bookmarks_path(question, question_id: question.id), method: :post do %>
+                        <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                      <% end %>
+                    <% end %>
+                  <% else %>
+                    <!--ユーザーが未ログインの場合はログインページに遷移する-->
+                    <%= link_to new_user_session_path do %>
+                      <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                    <% end %>
+                  <% end %>
+                  <span class="ml-1" style="font-size: 16px;"><%= question.bookmarks.count %></span>
+                  <i class="fas fa-eye ml-4 pt-1"  style="font-size: 20px;"></i>
+                  <span class="ml-1" style="font-size: 16px;"><%= question.views_count %></span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+
+        </div>
+
+        <!--ページネーションの設定-->
+        <div class="row">
+          <div class="mt-4 mx-auto">
+            <%= paginate @questions, theme: 'bootstrap-5' %>
+          </div>
+        </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/public/questions/new.html.erb
+++ b/app/views/public/questions/new.html.erb
@@ -7,7 +7,7 @@
 
       <div class="content-box", style="margin-top: 100px;">
 
-        <h4 class="ml-5 mt-4 font-weight-bold">質問作成</h4>
+        <h4 class="ml-5 mt-4 pb-3 font-weight-bold">質問作成</h4>
 
         <div class="mt-4 form-group">
           <%= form_with model: @question, url: questions_path do |f| %>
@@ -25,7 +25,7 @@
                       </td>
                   </tr>
                   <tr>
-                    <td class="pt-4 align-middle font-weight-bold">質問内容</td>
+                    <td class="align-middle font-weight-bold">質問内容</td>
                   </tr>
                   <tr>
                     <td>

--- a/app/views/public/questions/new.html.erb
+++ b/app/views/public/questions/new.html.erb
@@ -1,2 +1,70 @@
-<h1>Public::Questions#new</h1>
-<p>Find me in app/views/public/questions/new.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <!--エラーメッセージ-->
+      <%= render 'layouts/errors', obj: @question %>
+
+      <div class="content-box", style="margin-top: 100px;">
+
+        <h4 class="ml-5 mt-4 font-weight-bold">質問作成</h4>
+
+        <div class="mt-4 form-group">
+          <%= form_with model: @question, url: questions_path do |f| %>
+            <!--新規質問登録フォーム-->
+            <div class="row">
+              <div class="col-11 mx-auto">
+                <table class="table table-borderless">
+                  <tr>
+                    <td class="align-middle font-weight-bold">タイトル</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <%= f.text_field :title, placeholder: "タイトルを入力", class: "form-control" %>
+                      <div id="title-count" class="mt-1 text-right text-muted">0 / 50文字</div>
+                      </td>
+                  </tr>
+                  <tr>
+                    <td class="pt-4 align-middle font-weight-bold">質問内容</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <%= f.text_area :body, placeholder: "質問本文を入力", class: "form-control", style: "height: 160px;" %>
+                      <div id="body-count" class="mt-1 text-right text-muted">0 / 300文字</div>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </div>
+            <!--新規質問作成ボタン-->
+            <div class="text-center">
+              <%= f.submit "質問を作成する", class: "mt-2 btn btn-primary btn-lg" %>
+            </div>
+          <% end %>
+        </div>
+
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!--文字数カウンター-->
+<script>
+  $(document).ready(function() {
+    const textField = $("#question_title");
+    const textArea = $("#question_body");
+    const titleCount = $("#title-count");
+    const bodyCount = $("#body-count");
+
+    textField.on("input", function() {
+      const count = textField.val().length;
+      titleCount.text(count + " / 50文字");
+    })
+
+    textArea.on("input", function() {
+      const count = textArea.val().length;
+      bodyCount.text(count + " / 300文字");
+    });
+  });
+</script>

--- a/app/views/public/questions/new.html.erb
+++ b/app/views/public/questions/new.html.erb
@@ -38,7 +38,7 @@
             </div>
             <!--新規質問作成ボタン-->
             <div class="text-center">
-              <%= f.submit "質問を作成する", class: "mt-2 btn btn-primary btn-lg" %>
+              <%= f.submit "質問を作成する", class: "mt-2 btn btn-primary btn-lg", data: {confirm: "質問文は後から変更できません。投稿しますか？"} %>
             </div>
           <% end %>
         </div>

--- a/app/views/public/questions/show.html.erb
+++ b/app/views/public/questions/show.html.erb
@@ -10,7 +10,7 @@
         <div class="row">
           <!--質問者情報-->
           <div class="col-8">
-            <div class="profile-image mt-3">
+            <div class="delete-underline mt-3 ml-2">
               <%= link_to user_path(@question.user) do %>
                 <%= image_tag @question.user.get_profile_image(40, 40), class: "rounded-circle mr-1" %>
               <% end %>
@@ -18,7 +18,7 @@
             </div>
           </div>
           <!--ブックマーク・閲覧数-->
-          <div class="offset-1 col-3 mt-4">
+          <div class="delete-underline offset-1 col-3 mt-4">
             <!--ブックマークボタン-->
             <% if current_user %>
               <% if @question.bookmarked_by?(current_user) %>
@@ -69,12 +69,13 @@
       </div>
 
       <!--回答一覧-->
-      <div class="content-box mt-4">
+      <div class="content-box my-4">
         <h5 class="ml-5 mt-4 font-weight-bold">回答一覧</h4>
         <!--1回答-->
         <% @question.answers.each do |answer| %>
-          <div class="question mt-3 border mx-auto">
-            <div class="profile-image mt-3 ml-3">
+          <div class="question my-3 border mx-auto">
+            <!--回答者情報-->
+            <div class="delete-underline mt-3 ml-3">
               <%= link_to user_path(answer.user) do %>
                 <%= image_tag answer.user.get_profile_image(40, 40), class: "rounded-circle mr-1" %>
               <% end %>
@@ -84,12 +85,50 @@
             <div class="h5 px-5 pt-3">
               <%= answer.body %>
             </div>
-            <div class="py-3 pr-4 text-right" style="font-size: 14px;">
+            <!--評価ボタン-->
+            <div class="text-right mt-4 pr-4", style="font-size: 20px;">
+              <% if current_user %>
+                <% if answer.evaluated_by?(current_user) %>
+                  <%= link_to question_answer_evaluations_path(answer, answer_id: answer.id), method: :delete do %>
+                    <i class="fas fa-fire-alt fa-lg text-danger"></i>
+                  <% end %>
+                <% else %>
+                  <%= link_to question_answer_evaluations_path(answer, answer_id: answer.id), method: :post do %>
+                    <i class="fas fa-bomb fa-lg text-dark"></i>
+                  <% end %>
+                <% end %>
+              <% else %>
+                <!--ユーザーが未ログインの場合はログインページに遷移する-->
+                <%= link_to new_user_session_path do %>
+                  <i class="fas fa-bomb fa-lg text-dark"></i>
+                <% end %>
+              <% end %>
+              <%= answer.evaluations.count %>
+            </div>
+            <div class="pt-2 pb-3 pr-4 text-right" style="font-size: 14px;">
               <%= answer.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
             </div>
           </div>
         <% end %>
 
+      </div>
+
+      <!--ページ送り-->
+      <div class="row my-4 pl-4 mx-auto">
+        <div class="col-3">
+          <% if @previous_question %>
+            <%= link_to question_path(@previous_question), class: "btn btn-primary" do %>
+              <i class="fa-solid fa-left-long"></i> 前の質問へ
+            <% end %>
+          <% end %>
+        </div>
+        <div class="offset-6 col-3">
+          <% if @next_question %>
+            <%= link_to question_path(@next_question), class: "btn btn-primary" do %>
+              次の質問へ <i class="fa-solid fa-right-long"></i>
+            <% end %>
+          <% end %>
+        </div>
       </div>
 
     </div>

--- a/app/views/public/questions/show.html.erb
+++ b/app/views/public/questions/show.html.erb
@@ -7,12 +7,41 @@
 
       <!--質問内容-->
       <div class="content-box mt-5">
-        <div class="profile-image mt-3">
-          <%= link_to user_path(@question.user) do %>
-            <%= image_tag @question.user.get_profile_image(40, 40), class: "rounded-circle mr-1" %>
-          <% end %>
-          <%= @question.user.name %>
+        <div class="row">
+          <!--質問者情報-->
+          <div class="col-8">
+            <div class="profile-image mt-3">
+              <%= link_to user_path(@question.user) do %>
+                <%= image_tag @question.user.get_profile_image(40, 40), class: "rounded-circle mr-1" %>
+              <% end %>
+              <%= @question.user.name %>
+            </div>
+          </div>
+          <!--ブックマーク・閲覧数-->
+          <div class="offset-1 col-3 mt-4">
+            <!--ブックマークボタン-->
+            <% if current_user %>
+              <% if @question.bookmarked_by?(current_user) %>
+                <%= link_to question_bookmark_path(@question, question_id: @question.id), method: :delete do %>
+                  <i class="fa-solid fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                <% end %>
+              <% else %>
+                <%= link_to question_bookmarks_path(@question), method: :post do %>
+                  <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+                <% end %>
+              <% end %>
+            <% else %>
+              <!--ユーザーが未ログインの場合はログインページに遷移する-->
+              <%= link_to new_user_session_path do %>
+                <i class="far fa-bookmark" aria-hidden="true" style="font-size: 20px; color: gray;"></i>
+              <% end %>
+            <% end %>
+            <span class="ml-1" style="font-size: 16px;"><%= @question.bookmarks.count %></span>
+            <i class="fas fa-eye ml-4 pt-1"  style="font-size: 20px;"></i>
+            <span class="ml-1" style="font-size: 16px;"><%= @question.views_count %></span>
+          </div>
         </div>
+        <!--質問本文-->
         <div class="h4 mt-4 px-3 font-weight-bold text-center">
           <%= @question.title %><hr style="width: 90%; border: none; height: 3px; background-color: #066285; border-radius: 10px;">
         </div>

--- a/app/views/public/questions/show.html.erb
+++ b/app/views/public/questions/show.html.erb
@@ -1,2 +1,81 @@
-<h1>Public::Questions#show</h1>
-<p>Find me in app/views/public/questions/show.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <!--エラーメッセージ-->
+      <%= render 'layouts/errors', obj: @answer %>
+
+      <!--質問内容-->
+      <div class="content-box mt-5">
+        <div class="profile-image mt-3">
+          <%= link_to user_path(@question.user) do %>
+            <%= image_tag @question.user.get_profile_image(40, 40), class: "rounded-circle mr-1" %>
+          <% end %>
+          <%= @question.user.name %>
+        </div>
+        <div class="h4 mt-4 px-3 font-weight-bold text-center">
+          <%= @question.title %><hr style="width: 90%; border: none; height: 3px; background-color: #066285; border-radius: 10px;">
+        </div>
+        <div class="h5 p-4">
+          <%= @question.body %>
+        </div>
+        <div class="py-3 pr-4 text-right">
+          <%= @question.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
+        </div>
+      </div>
+
+      <!--回答送信フォーム-->
+      <div class="content-box mt-4">
+        <%= form_with model: [@question, @answer], url: question_answers_path(@question) do |f| %>
+          <div class="row">
+            <div class="col-10">
+              <%= f.text_area :body, placeholder: "回答を入力してください", class: "form-control", style: "height: 120px;" %>
+              <div id="body-count" class="mt-1 text-right text-muted">0 / 300文字</div>
+            </div>
+            <div class="col-2">
+              <%= f.submit "回答する", class: "btn btn-success", style: "height: 120px;" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <!--回答一覧-->
+      <div class="content-box mt-4">
+        <h5 class="ml-5 mt-4 font-weight-bold">回答一覧</h4>
+        <!--1回答-->
+        <% @question.answers.each do |answer| %>
+          <div class="question mt-3 border mx-auto">
+            <div class="profile-image mt-3 ml-3">
+              <%= link_to user_path(answer.user) do %>
+                <%= image_tag answer.user.get_profile_image(40, 40), class: "rounded-circle mr-1" %>
+              <% end %>
+              <%= answer.user.name %>
+            </div>
+            <!--回答文-->
+            <div class="h5 px-5 pt-3">
+              <%= answer.body %>
+            </div>
+            <div class="py-3 pr-4 text-right" style="font-size: 14px;">
+              <%= answer.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
+            </div>
+          </div>
+        <% end %>
+
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!--文字数カウンター-->
+<script>
+  $(document).ready(function() {
+    const textArea = $("#answer_body");
+    const bodyCount = $("#body-count");
+
+    textArea.on("input", function() {
+      const count = textArea.val().length;
+      bodyCount.text(count + " / 300文字");
+    });
+  });
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,9 +19,10 @@ Rails.application.routes.draw do
     resources :posts, only: [:index, :show]
 
     resources :questions, only: [:new, :create, :index, :show] do
-      resources :answers, only: [:create]
       resources :bookmarks, only: [:create, :destroy]
-      resource :evaluations, only: [:create, :destroy]
+      resources :answers, only: [:create] do
+        resource :evaluations, only: [:create, :destroy]
+      end
     end
 
     resources :users, only: [:show, :edit, :update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,12 +20,13 @@ Rails.application.routes.draw do
 
     resources :questions, only: [:new, :create, :index, :show] do
       resources :answers, only: [:create]
+      resources :bookmarks, only: [:create, :destroy]
       resource :evaluations, only: [:create, :destroy]
     end
 
-    resources :bookmarks, only: [:create, :index, :destroy]
-
-    resources :users, only: [:show, :edit, :update]
+    resources :users, only: [:show, :edit, :update] do
+      resources :bookmarks, only: [:index]
+    end
     get '/users/:id/confirm' => 'users#confirm'
     patch '/users/:id/quit' => 'users#quit'
 

--- a/db/migrate/20230604072121_create_questions.rb
+++ b/db/migrate/20230604072121_create_questions.rb
@@ -1,10 +1,11 @@
 class CreateQuestions < ActiveRecord::Migration[6.1]
   def change
     create_table :questions do |t|
-      
-      t.integer :user_id, null: false
-      t.string  :title,   null: false
-      t.text    :body,    null: false
+
+      t.integer :user_id,     null: false
+      t.string  :title,       null: false
+      t.text    :body,        null: false
+      t.integer :views_count, null: false, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20230604072136_create_evaluations.rb
+++ b/db/migrate/20230604072136_create_evaluations.rb
@@ -4,7 +4,6 @@ class CreateEvaluations < ActiveRecord::Migration[6.1]
       
       t.integer :user_id,   null: false
       t.integer :answer_id, null: false
-      t.integer :status
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,7 +70,6 @@ ActiveRecord::Schema.define(version: 2023_06_04_075029) do
   create_table "evaluations", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "answer_id", null: false
-    t.integer "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2023_06_04_075029) do
     t.integer "user_id", null: false
     t.string "title", null: false
     t.text "body", null: false
+    t.integer "views_count", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,6 +64,14 @@ Question.create!(
   ]
 )
 
+10.times do |n|
+  Question.create!(
+    user_id: 5,
+    title: "「鳥のさえずり」を中国語でいうと？#{n}",
+    body: "チュンチュン、というアレです。#{n}"
+  )
+end
+
 puts "--------- create Answer"
 Answer.create!(
   [

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,12 +94,10 @@ Evaluation.create!(
     {
       user_id: 3,
       answer_id: 1,
-      status: 0
     },
     {
       user_id: 3,
       answer_id: 2,
-      status: 1
     }
   ]
 )


### PR DESCRIPTION
以下の変更点を含みます。

### ルーティングの変更（bookmarks, evaluations）
それぞれ紐づき先のコントローラにネストさせました。
なお、bookmarksの:indexのみブックマーク一覧ページ作成のため、独立させています。

### evaluationテーブル内statusカラムの削除
これに伴い、モデル内enumの設定、seeds.rbの記述を削除しました。

### サイトの全体的なデザイン変更
- サイト全体的な色味の変更、一部文字色変更
- グラデーション背景の適用
- フォント2種の適用（ヘッダー用、メイン用）
- マウスオーバー時の色変化の有無や変化先の色の指定
- マウスオーバー時の下線の表示有無の指定
- TOPページレイアウトの微調整

### public/questions/index画面・機能の作成
- ページ内に配置したタブを切り替えることで、新着順/人気順のソートが可能
- 人気順は閲覧数を参照
- index画面上で各質問のブックマーク追加/削除、閲覧数の確認が可能（TOPページも同様）

### public/questions/new画面・機能の作成
- タイトル、質問内容の各欄右下部にJSによる文字数カウンターの配置
- バリデーションでかけている文字数をオーバーした上で作成を試みるとバリデーションエラーが表示
- 「質問を作成する」押下時、後から編集できませんが投稿しますか、といった旨の確認アラートを表示

### public/questions/show画面・機能の作成
- ページ内のユーザープロフィール画像から、各ユーザーのマイページに遷移（質問者・回答者問わず）
- 本ページからもブックマーク追加/削除、閲覧数の確認が可能
- 回答欄は大きめに設置し、右下部にはJSによる文字数カウンターの配置
- 回答一覧内の各質問右下では、評価（いいね）機能としてアイコンを設置
- 自身の回答には自身で評価をつけることは不可
- public/today_words, public/posts同様、show内から前の/次の質問に遷移できるボタンを配置
- 既に削除されている記事は自動で飛ばし、そういった記事に直接検索でアクセスを試みた場合にindexに飛ばす処理を記述