### PR TITLE
[Update] admin/questions, admin/answersの画面・機能実装

### DIFF
--- a/app/controllers/admin/answers_controller.rb
+++ b/app/controllers/admin/answers_controller.rb
@@ -6,6 +6,10 @@ class Admin::AnswersController < Admin::ApplicationController
   end
 
   def destroy
+    @question = Question.find(params[:question_id])
+    @answer = @question.answers.find(params[:id])
+    @answer.destroy
+    redirect_to admin_question_answers_path
   end
 
 end

--- a/app/controllers/admin/answers_controller.rb
+++ b/app/controllers/admin/answers_controller.rb
@@ -1,6 +1,8 @@
 class Admin::AnswersController < Admin::ApplicationController
 
   def index
+    @question = Question.find(params[:question_id])
+    @answers = @question.answers.page(params[:page]).per(10)
   end
 
   def destroy

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,8 +1,8 @@
 class Admin::GenresController < Admin::ApplicationController
 
   def create
-    if Genre.count >= 13
-      flash[:alert] = "作成可能なジャンルは最大13項目です。"
+    if Genre.count >= 10
+      flash[:alert] = "作成可能なジャンルは最大10項目です。"
       redirect_to request.referer
     else
       @genre = Genre.new(genre_params)

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -4,9 +4,6 @@ class Admin::QuestionsController < Admin::ApplicationController
     @questions = Question.all.page(params[:page]).per(10)
   end
 
-  def show
-  end
-
   def destroy
   end
 

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -1,12 +1,13 @@
 class Admin::QuestionsController < Admin::ApplicationController
-  
+
   def index
+    @questions = Question.all.page(params[:page]).per(10)
   end
 
   def show
   end
-  
+
   def destroy
   end
-  
+
 end

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -5,6 +5,9 @@ class Admin::QuestionsController < Admin::ApplicationController
   end
 
   def destroy
+    @question = Question.find(params[:id])
+    @question.destroy
+    redirect_to admin_questions_path
   end
 
 end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -11,11 +11,12 @@ class Public::PostsController < Public::ApplicationController
 
   def show
     @post = Post.find_by(id: params[:id])
-    @previous_post = Post.where("id < ? AND is_active = ?", @post, true).order(id: "DESC").first
-    @next_post = Post.where("id > ? AND is_active = ?", @post, true).order(:id).first
 
     if @post.nil? || !@post.is_active
       redirect_to posts_path, alert: "記事が見つかりません。"
+    else
+      @previous_post = Post.where("id < ? AND is_active = ?", @post, true).order(id: "DESC").first
+      @next_post = Post.where("id > ? AND is_active = ?", @post, true).order(:id).first
     end
   end
 

--- a/app/controllers/public/questions_controller.rb
+++ b/app/controllers/public/questions_controller.rb
@@ -29,14 +29,15 @@ class Public::QuestionsController < Public::ApplicationController
 
   def show
     @question = Question.find_by(id: params[:id])
-    @question.increment_views_count!
-    @answer = Answer.new
-
-    @previous_question = Question.where("id < ?", @question).order(id: "DESC").first
-    @next_question = Question.where("id > ?", @question).order(:id).first
 
     if @question.nil?
       redirect_to questions_path, alert: "質問が見つかりません。"
+    else
+      @question.increment_views_count!
+      @answer = Answer.new
+
+      @previous_question = Question.where("id < ?", @question).order(id: "DESC").first
+      @next_question = Question.where("id > ?", @question).order(:id).first
     end
   end
 

--- a/app/controllers/public/today_words_controller.rb
+++ b/app/controllers/public/today_words_controller.rb
@@ -6,11 +6,12 @@ class Public::TodayWordsController < Public::ApplicationController
 
   def show
     @today_word = TodayWord.find_by(id: params[:id])
-    @previous_word = TodayWord.where("id < ? AND is_active = ?", @today_word, true).order(id: "DESC").first
-    @next_word = TodayWord.where("id > ? AND is_active = ?", @today_word, true).order(:id).first
 
     if @today_word.nil? || !@today_word.is_active
       redirect_to today_words_path, alert: "単語が見つかりません。"
+    else
+      @previous_word = TodayWord.where("id < ? AND is_active = ?", @today_word, true).order(id: "DESC").first
+      @next_word = TodayWord.where("id > ? AND is_active = ?", @today_word, true).order(:id).first
     end
   end
 

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -13,6 +13,11 @@ body{
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
 }
 
+.admin-box{
+  background-color: rgb(255, 255, 255);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+}
+
 .news{
   border-radius: 10px;
   width: 225px;

--- a/app/views/admin/answers/index.html.erb
+++ b/app/views/admin/answers/index.html.erb
@@ -1,2 +1,41 @@
-<h1>Admin::Answers#index</h1>
-<p>Find me in app/views/admin/answers/index.html.erb</p>
+<div class="container my-5">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <h5 class="h4 ml-5 pt-4 font-weight-bold">質問ID:<%= @question.id %>の回答管理</h5>
+
+      <div class="admin-box mx-auto px-4">
+        <!--各列カラム名-->
+        <table class="table table-colored mt-3">
+          <thead>
+            <tr>
+              <th>回答ID</th>
+              <th>回答文</th>
+              <th></th>
+            </tr>
+          </thead>
+
+          <!--質問一覧-->
+          <% @answers.each do |answer| %>
+            <tbody>
+              <tr>
+                <td class="align-middle"><%= answer.id %></td>
+                <td class="align-middle"><%= truncate(answer.body, length: 30, omission: '...') %></td>
+                <td><%= link_to "削除", admin_question_answer_path(@question, answer), class: "btn btn-danger btn-sm", method: :delete, data: {confirm: "削除しますか？"} %></td>
+              </tr>
+            </tbody>
+          <% end %>
+
+        </table>
+      </div>
+
+      <!--ページネーションの設定-->
+      <div class="row">
+        <div class="mt-2 mx-auto">
+          <%= paginate @answers, theme: 'bootstrap-5' %>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/admin/answers/index.html.erb
+++ b/app/views/admin/answers/index.html.erb
@@ -15,7 +15,7 @@
             </tr>
           </thead>
 
-          <!--質問一覧-->
+          <!--回答一覧-->
           <% @answers.each do |answer| %>
             <tbody>
               <tr>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -3,8 +3,8 @@
     <div class="offset-1 col-11">
 
       <div class="row">
-        <div class="col-6">
-           <h5 class="term-title ml-2 font-weight-bold">ジャンル管理（最大13項目）</h5>
+        <div class="col-8">
+           <h5 class="h4 ml-5 pt-4 font-weight-bold">ジャンル管理</h5>
         </div>
 
         <!--ジャンル新規登録欄（ポップアップ表示）-->
@@ -14,7 +14,7 @@
               <tr>
                 <td>
                   <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
-                    <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
+                    <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（同名不可・最大6文字）", class: "col-8 form-control mr-2" %>
                     <%= f.submit "ジャンル作成", class:"col-3 btn btn-primary" %><br>
                     <p class="text-white pt-3"> ※作成をやめる場合は画面外をクリック</p>
                   <% end %>
@@ -24,45 +24,47 @@
         </div>
 
         <!--ジャンル作成ボタン-->
-        <div class="offset-3 col-3 mt-3">
-          <div class="py-2 px-3 btn btn-primary" id="new-genre-button">
+        <div class="col-4 mt-3">
+          <div class="py-2 px-3 ml-4 btn btn-primary" id="new-genre-button">
              <i class="fa-solid fa-tags fa-lg"></i> ジャンル作成
           </div>
         </div>
       </div>
 
-      <!--各列カラム名-->
-      <table class="table table-colored mt-3">
-        <thead>
-          <tr>
-            <th>ジャンルID</th>
-            <th>ジャンル名</th>
-            <th>記事の投稿数</th>
-            <th></th>
-          </tr>
-        </thead>
-
-        <!--ジャンル一覧-->
-        <% @genres.each do |genre| %>
-          <tbody>
+      <div class="admin-box mx-auto px-4">
+        <!--各列カラム名-->
+        <table class="table table-colored mt-3">
+          <thead>
             <tr>
-              <td class="align-middle"><%= genre.id %></td>
-              <%= form_with model: [:admin, genre], url: admin_genre_path(genre) do |f| %>
-                <td class="align-middle">
-                  <span class="genre-name"><%= genre.name %></span>
-                  <%= f.text_field :name, placeholder: "ジャンル名を入力", class: "genre-edit-input", style: "display: none;" %>
-                </td>
-                <td class="align-middle"><%= genre.posts.count %></td>
-                <td>
-                  <div class="py-2 px-3 btn btn-success btn-sm edit-button">編集</div>
-                  <%= f.submit "保存", class: "py-2 px-3 btn btn-primary btn-sm save-button", style: "display: none;" %>
-                </td>
-              <% end %>
+              <th>ジャンルID</th>
+              <th>ジャンル名（最大6文字）</th>
+              <th>記事の投稿数</th>
+              <th></th>
             </tr>
-          </tbody>
-        <% end %>
+          </thead>
 
-      </table>
+          <!--ジャンル一覧-->
+          <% @genres.each do |genre| %>
+            <tbody>
+              <tr>
+                <td class="align-middle"><%= genre.id %></td>
+                <%= form_with model: [:admin, genre], url: admin_genre_path(genre) do |f| %>
+                  <td class="align-middle">
+                    <span class="genre-name"><%= genre.name %></span>
+                    <%= f.text_field :name, placeholder: "ジャンル名（最大6文字）", class: "genre-edit-input", style: "display: none;" %>
+                  </td>
+                  <td class="align-middle"><%= genre.posts.count %></td>
+                  <td>
+                    <div class="py-2 px-3 btn btn-success btn-sm edit-button">編集</div>
+                    <%= f.submit "保存", class: "py-2 px-3 btn btn-primary btn-sm save-button", style: "display: none;" %>
+                  </td>
+                <% end %>
+              </tr>
+            </tbody>
+          <% end %>
+
+        </table>
+      </div>
 
     </div>
   </div>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -5,7 +5,7 @@
       <!--エラーメッセージ-->
       <%= render 'layouts/errors', obj: @post %>
 
-      <h5 class="term-title ml-2 font-weight-bold">ニュース編集</h5>
+      <h5 class="h4 ml-5 pt-4 font-weight-bold">ニュース編集</h5>
 
       <!--ジャンル新規登録欄（ポップアップ表示）-->
       <div class="col-10 mx-auto form-group" id="new-genre-form"

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -14,7 +14,7 @@
             <tr>
               <td>
                 <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
-                  <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
+                  <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（同名不可・最大6文字）", class: "col-8 form-control mr-2" %>
                   <%= f.submit "ジャンル作成", class:"col-3 btn btn-primary" %><br>
                   <p class="text-white pt-3"> ※作成をやめる場合は画面外をクリック</p>
                 <% end %>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -3,56 +3,58 @@
     <div class="offset-1 col-11">
 
       <div class="row">
-        <div class="col-3">
-           <h5 class="term-title ml-2 font-weight-bold">ニュース管理</h5>
+        <div class="col-5">
+           <h5 class="h4 ml-5 pt-4 font-weight-bold">ニュース管理</h5>
         </div>
 
         <!--ジャンル管理ボタン-->
-        <div class="col-3 mt-3">
+        <div class="offset-1 col-3 mt-3">
           <%= link_to admin_genres_path, class: "py-2 px-3 btn btn-outline-warning" do %>
             <i class="fa-solid fa-tags fa-lg"></i> ジャンル管理
           <% end %>
         </div>
 
         <!--新規投稿ボタン-->
-        <div class="offset-3 col-3 mt-3">
+        <div class="col-3 mt-3">
           <%= link_to new_admin_post_path, class: "py-2 px-3 btn btn-primary" do %>
             <i class="fa-solid fa-folder-plus fa-lg"></i> 新規投稿
           <% end %>
         </div>
       </div>
 
-      <!--各列カラム名-->
-      <table class="table table-colored mt-3">
-        <thead>
-          <tr>
-            <th>記事ID</th>
-            <th>タイトル</th>
-            <th>ステータス</th>
-            <th colspan="2"></th>
-          </tr>
-        </thead>
-
-        <!--記事一覧-->
-        <% @posts.each do |post| %>
-          <tbody>
+      <div class="admin-box mx-auto px-4">
+        <!--各列カラム名-->
+        <table class="table table-colored mt-3">
+          <thead>
             <tr>
-              <td class="align-middle"><%= post.id %></td>
-              <td class="align-middle"><%= post.title %></td>
-              <td class="align-middle">
-                <% if post.is_active %>
-                  <span style="color: green;">有効</span>
-                <% else %>
-                  <span style="color: gray;" >無効</span>
-                <% end %>
-              </td>
-              <td><%= link_to "編集", edit_admin_post_path(post), class: "btn btn-success btn-sm" %></td>
-              <td><%= link_to "削除", admin_post_path(post), class: "btn btn-danger btn-sm", method: :delete, data: {confirm: "削除しますか？"} %></td>
+              <th>記事ID</th>
+              <th>タイトル</th>
+              <th>ステータス</th>
+              <th colspan="2"></th>
             </tr>
-          </tbody>
-        <% end %>
+          </thead>
 
-      </table>
+          <!--記事一覧-->
+          <% @posts.each do |post| %>
+            <tbody>
+              <tr>
+                <td class="align-middle"><%= post.id %></td>
+                <td class="align-middle"><%= truncate(post.title, length: 21, omission: '...') %></td>
+                <td class="align-middle">
+                  <% if post.is_active %>
+                    <span style="color: green;">有効</span>
+                  <% else %>
+                    <span style="color: gray;" >無効</span>
+                  <% end %>
+                </td>
+                <td><%= link_to "編集", edit_admin_post_path(post), class: "btn btn-success btn-sm" %></td>
+                <td><%= link_to "削除", admin_post_path(post), class: "btn btn-danger btn-sm", method: :delete, data: {confirm: "削除しますか？"} %></td>
+              </tr>
+            </tbody>
+          <% end %>
+
+        </table>
+      </div>
 
       <!--ページネーションの設定-->
       <div class="row">

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -14,7 +14,7 @@
             <tr>
               <td>
                 <%= form_with model: @genre, url: admin_genres_path, html: { class: "form-inline" } do |f| %>
-                  <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（最大6文字）", class: "col-8 form-control mr-2" %>
+                  <%= f.text_field :name, name: "genre[name]", placeholder: "新規ジャンル名（同名不可・最大6文字）", class: "col-8 form-control mr-2" %>
                   <%= f.submit "ジャンル作成", class:"col-3 btn btn-primary" %><br>
                   <p class="text-white pt-3"> ※作成をやめる場合は画面外をクリック</p>
                 <% end %>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -5,7 +5,7 @@
       <!--エラーメッセージ-->
       <%= render 'layouts/errors', obj: @post %>
 
-      <h5 class="term-title ml-2 font-weight-bold">ニュース登録</h5>
+      <h5 class="h4 ml-5 pt-4 font-weight-bold">ニュース登録</h5>
 
       <!--ジャンル新規登録欄（ポップアップ表示）-->
       <div class="col-10 mx-auto form-group" id="new-genre-form"

--- a/app/views/admin/questions/index.html.erb
+++ b/app/views/admin/questions/index.html.erb
@@ -1,2 +1,52 @@
-<h1>Admin::Questions#index</h1>
-<p>Find me in app/views/admin/questions/index.html.erb</p>
+<div class="container my-5">
+  <div class="row">
+    <div class="offset-1 col-11">
+
+      <div class="row">
+        <div class="col-6">
+           <h5 class="h4 ml-5 pt-4 font-weight-bold">質問管理</h5>
+        </div>
+
+        <!--検索欄-->
+        <div class="col-6 input-group mt-3">
+          <input class="form-control" placeholder="質問を検索">
+          <button class="btn btn-outline-success", style="height: 86%;"><i class="fas fa-search"></i> 検索</button>
+        </div>
+      </div>
+
+      <div class="admin-box mx-auto px-4">
+        <!--各列カラム名-->
+        <table class="table table-colored mt-3">
+          <thead>
+            <tr>
+              <th>質問ID</th>
+              <th>タイトル</th>
+              <th colspan="2"></th>
+            </tr>
+          </thead>
+
+          <!--質問一覧-->
+          <% @questions.each do |question| %>
+            <tbody>
+              <tr>
+                <td class="align-middle"><%= question.id %></td>
+                <td class="align-middle"><%= truncate(question.title, length: 18, omission: '...') %></td>
+                <td><%= link_to "回答を見る", admin_question_answers_path(question), class: "btn btn-success btn-sm" %></td>
+                <td><%= link_to "削除", admin_question_path(question), class: "btn btn-danger btn-sm", method: :delete, data: {confirm: "削除しますか？"} %></td>
+              </tr>
+            </tbody>
+          <% end %>
+
+        </table>
+      </div>
+
+      <!--ページネーションの設定-->
+      <div class="row">
+        <div class="mt-2 mx-auto">
+          <%= paginate @questions, theme: 'bootstrap-5' %>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/admin/questions/show.html.erb
+++ b/app/views/admin/questions/show.html.erb
@@ -1,2 +1,0 @@
-<h1>Admin::Questions#show</h1>
-<p>Find me in app/views/admin/questions/show.html.erb</p>

--- a/app/views/admin/today_words/edit.html.erb
+++ b/app/views/admin/today_words/edit.html.erb
@@ -5,7 +5,7 @@
       <!--エラーメッセージ-->
       <%= render 'layouts/errors', obj: @today_word %>
 
-      <h5 class="term-title ml-2 font-weight-bold">今日の中国語編集</h5>
+      <h5 class="h4 ml-5 pt-4 font-weight-bold">今日の中国語編集</h5>
 
       <div class="mt-4 form-group">
         <%= form_with model: [:admin, @today_word], url: admin_today_word_path do |f| %>

--- a/app/views/admin/today_words/index.html.erb
+++ b/app/views/admin/today_words/index.html.erb
@@ -15,41 +15,41 @@
         </div>
       </div>
 
-    <div class="admin-box mx-auto px-4">
-      <!--各列カラム名-->
-      <table class="table table-colored mt-3">
-        <thead>
-          <tr>
-            <th>単語ID</th>
-            <th>中国語</th>
-            <th>日本語</th>
-            <th>ステータス</th>
-            <th colspan="2"></th>
-          </tr>
-        </thead>
-
-        <!--単語一覧-->
-        <% @today_words.each do |today_word| %>
-          <tbody>
+      <div class="admin-box mx-auto px-4">
+        <!--各列カラム名-->
+        <table class="table table-colored mt-3">
+          <thead>
             <tr>
-              <td class="align-middle"><%= today_word.id %></td>
-              <td class="align-middle"><%= truncate(today_word.chinese, length: 9, omission: '...') %></td>
-              <td class="align-middle"><%= truncate(today_word.japanese, length: 9, omission: '...') %></td>
-              <td class="align-middle">
-                <% if today_word.is_active %>
-                  <span style="color: green;">有効</span>
-                <% else %>
-                  <span style="color: gray;" >無効</span>
-                <% end %>
-              </td>
-              <td><%= link_to "編集", edit_admin_today_word_path(today_word), class: "btn btn-success btn-sm" %></td>
-              <td><%= link_to "削除", admin_today_word_path(today_word), class: "btn btn-danger btn-sm", method: :delete, data: {confirm: "削除しますか？"} %></td>
+              <th>単語ID</th>
+              <th>中国語</th>
+              <th>日本語</th>
+              <th>ステータス</th>
+              <th colspan="2"></th>
             </tr>
-          </tbody>
-        <% end %>
+          </thead>
 
-      </table>
-    </div>
+          <!--単語一覧-->
+          <% @today_words.each do |today_word| %>
+            <tbody>
+              <tr>
+                <td class="align-middle"><%= today_word.id %></td>
+                <td class="align-middle"><%= truncate(today_word.chinese, length: 9, omission: '...') %></td>
+                <td class="align-middle"><%= truncate(today_word.japanese, length: 9, omission: '...') %></td>
+                <td class="align-middle">
+                  <% if today_word.is_active %>
+                    <span style="color: green;">有効</span>
+                  <% else %>
+                    <span style="color: gray;" >無効</span>
+                  <% end %>
+                </td>
+                <td><%= link_to "編集", edit_admin_today_word_path(today_word), class: "btn btn-success btn-sm" %></td>
+                <td><%= link_to "削除", admin_today_word_path(today_word), class: "btn btn-danger btn-sm", method: :delete, data: {confirm: "削除しますか？"} %></td>
+              </tr>
+            </tbody>
+          <% end %>
+
+        </table>
+      </div>
 
       <!--ページネーションの設定-->
       <div class="row">

--- a/app/views/admin/today_words/index.html.erb
+++ b/app/views/admin/today_words/index.html.erb
@@ -4,7 +4,7 @@
 
       <div class="row">
         <div class="col-9">
-           <h5 class="term-title ml-2 font-weight-bold">今日の中国語管理</h5>
+           <h5 class="h4 ml-5 pt-4 font-weight-bold">今日の中国語管理</h5>
         </div>
 
         <!--単語登録ボタン-->
@@ -15,6 +15,7 @@
         </div>
       </div>
 
+    <div class="admin-box mx-auto px-4">
       <!--各列カラム名-->
       <table class="table table-colored mt-3">
         <thead>
@@ -32,8 +33,8 @@
           <tbody>
             <tr>
               <td class="align-middle"><%= today_word.id %></td>
-              <td class="align-middle"><%= today_word.chinese %></td>
-              <td class="align-middle"><%= today_word.japanese %></td>
+              <td class="align-middle"><%= truncate(today_word.chinese, length: 9, omission: '...') %></td>
+              <td class="align-middle"><%= truncate(today_word.japanese, length: 9, omission: '...') %></td>
               <td class="align-middle">
                 <% if today_word.is_active %>
                   <span style="color: green;">有効</span>
@@ -48,6 +49,7 @@
         <% end %>
 
       </table>
+    </div>
 
       <!--ページネーションの設定-->
       <div class="row">

--- a/app/views/admin/today_words/new.html.erb
+++ b/app/views/admin/today_words/new.html.erb
@@ -5,7 +5,7 @@
       <!--エラーメッセージ-->
       <%= render 'layouts/errors', obj: @today_word %>
 
-      <h5 class="term-title ml-2 font-weight-bold">今日の中国語登録</h5>
+      <h5 class="h4 ml-5 pt-4 font-weight-bold">今日の中国語登録</h5>
 
       <div class="mt-4 form-group">
         <%= form_with model: [:admin, @today_word], url: admin_today_words_path do |f| %>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -3,11 +3,13 @@
     <div class="offset-1 col-11">
       <div class="content-box word_card" style="margin-top: 100px">
 
-        <!--記事タイトル-->
+        <!--記事タイトル欄-->
         <div class="my-3">
-          <div class="my-2 mx-3 border text-center text-dark" style="width: 23%; font-size: 18px">
-            <%= link_to @post.genre.name, posts_path(genre_id: @post.genre_id), class: "text-dark" %>
-          </div>
+          <%= link_to posts_path(genre_id: @post.genre_id) do %>
+            <div class="my-2 mx-3 border border-dark text-center text-dark" style="width: 23%; font-size: 18px;">
+              <%= @post.genre.name %>
+            </div>
+          <% end %>
           <div class="m-3 font-weight-bold" style="font-size: 26px">
             <%= @post.title %>
           </div>
@@ -18,7 +20,7 @@
         </div>
 
 
-        <!--記事見出し-->
+        <!--記事見出し画像-->
         <div><%= image_tag @post.get_image(685, 466) %></div>
 
         <!--記事本文-->

--- a/app/views/public/questions/new.html.erb
+++ b/app/views/public/questions/new.html.erb
@@ -20,16 +20,16 @@
                   </tr>
                   <tr>
                     <td>
-                      <%= f.text_field :title, placeholder: "タイトルを入力", class: "form-control" %>
+                      <%= f.text_field :title, placeholder: "質問タイトルを入力してください", class: "form-control" %>
                       <div id="title-count" class="mt-1 text-right text-muted">0 / 50文字</div>
                       </td>
                   </tr>
                   <tr>
-                    <td class="align-middle font-weight-bold">質問内容</td>
+                    <td class="align-middle font-weight-bold">質問文</td>
                   </tr>
                   <tr>
                     <td>
-                      <%= f.text_area :body, placeholder: "質問本文を入力", class: "form-control", style: "height: 160px;" %>
+                      <%= f.text_area :body, placeholder: "質問内容を入力してください", class: "form-control", style: "height: 160px;" %>
                       <div id="body-count" class="mt-1 text-right text-muted">0 / 300文字</div>
                     </td>
                   </tr>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -58,3 +58,8 @@ ja:
       post:
         title: "タイトル"
         body: "本文"
+      question:
+        title: "タイトル"
+        body: "質問文"
+      answer:
+        body: "回答文"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -55,7 +55,6 @@ ja:
         description: "一言解説"
         synonym: "同義語"
         is_active: "公開ステータス"
-      # question:
-      #   user_id: "会員ID"
-      #   title: "タイトル"
-      #   body: "質問文"
+      post:
+        title: "タイトル"
+        body: "本文"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
 
     resources :posts, only: [:new, :create, :index, :edit, :update, :destroy]
 
-    resources :questions, only: [:index, :show, :destroy] do
+    resources :questions, only: [:index, :destroy] do
       resources :answers, only: [:index, :destroy]
     end
 


### PR DESCRIPTION
以下の変更点を含みます。

### 管理側全体のレイアウト調整
- admin/today_words
- admin/posts
- admin/genres
common.scss内にadmin-boxなるクラスを作成し、admin側の要素に適用しました。

### 最大作成可能ジャンル数を13→10に変更
TOPページレイアウトの崩れを防ぐため上限作成数を13としていましたが、他の一覧ページに合わせて10に変更しました。

### エラー文の日本語訳を追加
- Postテーブルに関連する入力欄の分のみ
- Questionテーブルに関連する入力欄の分のみ

### public/posts/show内のジャンル別遷移リンクの適用範囲変更
記事詳細ページ内において記事のジャンル名が表示されている部分に対し、文字のみならず枠ごとリンクをつけました。

### admin/questions/showに関連するルーティング・アクションの削除
- routes.rbから該当する記述の削除
- controllerからshow記述の削除
- admin/questions/show.html.erbの削除

### admin/questionsの画面・機能実装
indexの画面及び、destroyの機能を実装しました。

### admin/answersの画面・機能実装
indexの画面及び、destroyの機能を実装しました。質問ごとの回答一覧が表示されます。

### public側 today_words, posts, questions内のshowアクション記述変更
if条件分岐を追加し、存在しないページにURLの直接入力でアクセスした場合に一覧画面に戻す処理を記述しました。
```
    if @today_word.nil? || !@today_word.is_active
      redirect_to today_words_path, alert: "単語が見つかりません。"
    else
      @previous_word = TodayWord.where("id < ? AND is_active = ?", @today_word, true).order(id: "DESC").first
      @next_word = TodayWord.where("id > ? AND is_active = ?", @today_word, true).order(:id).first
    end
```