### PR TITLE
[Update] ニュース一覧表示画面、ユーザーマイページ画面のレイアウト調整

### DIFF
--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -20,23 +20,12 @@ body{
 
 .news{
   border-radius: 10px;
-  width: 225px;
-  height: 275px;
   background-color: white;
-  .news-image{
-    width: 200px;
-    height: 136px;
-  }
+  height: 95%;
   .news-caption{
     font-weight: bold;
     color: black;
   }
-}
-
-.index-news{
-  border-radius: 10px;
-  height: 380px;
-  background-color: white;
 }
 
 .question{

--- a/app/javascript/stylesheets/responsive.scss
+++ b/app/javascript/stylesheets/responsive.scss
@@ -13,23 +13,6 @@
     top: 0;
   }
 
-  .news{
-    border-radius: 10px;
-    width: 32vh;
-    height: 35vh;
-    background-color: white;
-    .news-image{
-      transform: scale(1.25);
-    }
-  }
-
-  .index-news{
-    height: 40vh;
-    .index-news-image{
-      transform: scale(0.9);
-    }
-  }
-
   .devise-box{
     background-color: #f9f9f9;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
 
         <%= render 'layouts/hamburger', latest_today_word: @latest_today_word %>
 
-        <div class="col-md-3 d-none d-md-block fixed-sidebar text-center" style="background-color: #fccc4a; height: 100vh;">
+        <div class="col-lg-3 d-none d-lg-block fixed-sidebar text-center" style="background-color: #fccc4a; height: 100vh;">
           <p class="border border-dark p-5 mb-5 mt-3" style="font-size: 50px;">
             <%= link_to "LOGO", root_path, class: "text-dark" %>
           </p>
@@ -140,7 +140,7 @@
 
         </div>
 
-        <div class="main col-md-9 ">
+        <div class="main col-lg-9 ">
           <!--フラッシュメッセージ-->
           <%= render 'layouts/flash' %>
           <%= yield %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -27,23 +27,22 @@
           <span class="col-md-6 h3 ml-4 ml-md-5 font-weight-bold">新着ニュース</span>
         </div>
 
-        <!--1つの行に2記事を表示する-->
         <div class="row mx-auto w-100">
           <!--１記事-->
           <% @posts.each do |post| %>
             <div class="col-md-6">
               <%= link_to post_path(post.id) do %>
-                <div class="news border my-2 my-md-3">
-                  <div class="news-image mt-4 mt-md-2 mx-auto">
-                    <%= image_tag post.get_image(200, 136), class: "img-fluid", style: "border-radius: 10px;" %>
+                <div class="news border mx-auto my-2 my-md-3 d-flex flex-column">
+                  <div class="m-3">
+                    <%= image_tag post.get_image(400, 272), class: "img-fluid", style: "border-radius: 10px;" %>
                   </div>
-                  <div class="mt-4 mt-md-2 mb-1 mb-md-2 mx-3 mx-md-3 border text-center text-dark" style="width: 45%; font-size: 14px">
+                  <div class="mb-1 mb-md-2 mx-3 mx-md-3 border text-center text-dark" style="width: 45%; font-size: 14px;">
                     <%= post.genre.name %>
                   </div>
-                  <div class="news-caption ml-4 ml-md-3 mr-2 mr-md-1">
+                  <div class="news-caption ml-4 ml-md-3 mr-2 mr-md-1 flex-grow-1">
                     <%= truncate(post.title, length: 22, omission: '...') %>
                   </div>
-                  <div class="ml-4 ml-md-3 mb-2 mb-md-3 text-dark" style="font-size: 12px; position: absolute; bottom: 3%;">
+                  <div class="mt-5 ml-4 ml-md-3 mb-2 mb-md-3 text-dark" style="font-size: 12px;">
                     <i class="far fa-clock"></i>
                     <%= post.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
                   </div>

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -5,23 +5,22 @@
       <h3 class="pt-5 ml-5 font-weight-bold">ニュース一覧</h3>
 
       <div class="content-box mt-4">
-        <!--1つの行に2記事を表示する-->
         <div class="row mx-auto w-100">
           <!--１記事-->
           <% @posts.each do |post| %>
             <div class="col-md-6">
               <%= link_to post_path(post.id) do %>
-                <div class="index-news border my-3">
-                  <div class="index-news-image my-1 my-md-3 ml-1 ml-md-3">
-                    <%= image_tag post.get_image(280, 190), class: "img-fluid", style: "border-radius: 10px;" %>
+                <div class="news border mx-auto my-2 my-md-3 d-flex flex-column">
+                  <div class="m-3">
+                    <%= image_tag post.get_image(400, 272), class: "img-fluid", style: "border-radius: 10px;" %>
                   </div>
-                  <div class="my-2 mx-3 border text-center text-dark" style="width: 45%; font-size: 14px">
+                  <div class="mb-1 mb-md-2 mx-3 mx-md-3 border text-center text-dark" style="width: 45%; font-size: 14px;">
                     <%= post.genre.name %>
                   </div>
-                  <div class="ml-3 mr-2 font-weight-bold text-dark">
-                    <%= truncate(post.title, length: 48, omission: '...') %>
+                  <div class="news-caption ml-4 ml-md-3 mr-2 mr-md-1 flex-grow-1">
+                    <%= truncate(post.title, length: 22, omission: '...') %>
                   </div>
-                  <div class="m-3 text-dark" style="font-size: 12px; position: absolute; bottom: 3%;">
+                  <div class="mt-5 ml-4 ml-md-3 mb-2 mb-md-3 text-dark" style="font-size: 12px;">
                     <i class="far fa-clock"></i>
                     <%= post.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
                   </div>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -1,17 +1,17 @@
 <div class="container">
   <div class="row">
-    <div class="offset-md-1 col-md-11">
+    <div class="offset-lg-1 col-lg-11">
 
       <!--ユーザー情報-->
       <div class="content-box", style="margin: 100px 0;">
 
         <div class="row pt-md-4 px-md-4">
-          <div class="col-5 col-md-3 mr-md-5" style="height: 150px; width: 150px;">
+          <div class="col-5 col-md-3 pt-2 pt-md-0" style="height: 150px; width: 150px;">
             <%= image_tag @user.get_profile_image(150, 150), class: "img-fluid rounded-circle mr-5", style: "border: 3px solid #066285;" %>
           </div>
-          <div class="col-7 col-md-4 mt-4">
-            <h3 class="font-weight-bold"><%= @user.name %></h3>
-            <div class="mt-3 pl-1"><i class="fas fa-fire-alt fa-lg text-danger"></i> <%= @user.answer_rank_i18n %>ランク</div>
+          <div class="col-7 col-md-5 mt-4">
+            <h3 class="font-weight-bold responsive-text"><%= @user.name %></h3>
+            <div class="mt-3 pl-1 responsive-text"><i class="fas fa-fire-alt fa-lg text-danger pb-1 pb-md-0 responsive-text"></i> <%= @user.answer_rank_i18n %>ランク</div>
           </div>
           <div class="col-md-4 mt-md-3">
             <% if @user == current_user %>
@@ -26,7 +26,7 @@
         </div>
 
         <div class="row mt-4">
-          <table class="offset-1 col-6 offset-md-1 col-md-4 table table-borderless">
+          <table class="offset-1 col-8 offset-md-1 col-md-4 table table-borderless">
             <tr>
               <td class="align-middle font-weight-bold">性別：</td>
               <td><%= @user.gender_i18n %></td>


### PR DESCRIPTION
以下の変更点を含みます。

### ユーザーマイページ画面のレイアウト調整
サムネイルのサイズ、ユーザー名表示のフォントサイズを調整しました。

### ニュース一覧表示画面のレイアウト調整
どのサイズでも表示のされ方に大きな差が出ないようにしました。
また、親要素に"d-flex flex-colum"、子要素に"flex-grow-1"を適用することで、日付表示位置を固定しました。