### PR TITLE
[Update] ログイン後の遷移先を「直前までアクセスしようとしていたページ」に変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,19 +1,30 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_latest_today_word
+  before_action :store_user_location!, if: :storable_location?
 
   private
+
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+  end
+
+  def store_user_location!
+    store_location_for(:user, request.fullpath)
+  end
 
   def after_sign_in_path_for(resource)
     if resource.is_a?(Admin)
       admin_path
     else
-      user_path(current_user)
-    end
-  end
+      stored_location = stored_location_for(:user)
 
-  def after_sign_out_path_for(resource)
-    root_path
+      if stored_location.present?
+        stored_location
+      else
+        user_path(current_user)
+      end
+    end
   end
 
   def configure_permitted_parameters


### PR DESCRIPTION
以下の変更点を含みます。

### ログイン後の遷移先を直前まで見ようとしていた画面に変更
メソッド"store_user_location!", "storable_location?"をapplication.controller内に作成し、
ユーザーのログイン後は直前まで見ようとしていた画面に遷移するよう記述しました。