### PR TITLE
[Update] 会員側一部の一覧画面のみにスマホ表示時のpadding値の変更を適用

### DIFF
--- a/app/javascript/stylesheets/responsive.scss
+++ b/app/javascript/stylesheets/responsive.scss
@@ -55,7 +55,7 @@
     height: 18vh;
   }
 
-  .content-box {
+  .responsive-content-box .content-box {
     padding: 20px 0;
   }
 }

--- a/app/views/public/bookmarks/index.html.erb
+++ b/app/views/public/bookmarks/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container my-5 my-lg-0 pt-3 pt-lg-0">
+<div class="container responsive-content-box my-5 my-lg-0 pt-3 pt-lg-0">
   <div class="row">
     <div class="offset-lg-1 col-lg-11">
 

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,4 +1,4 @@
-<div class="container my-5 my-lg-3">
+<div class="container responsive-content-box my-5 my-lg-3">
 
   <!--今日の中国語-->
   <div class="row pt-4 pt-lg-0">

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container my-5 my-lg-0 pt-3 pt-lg-0">
+<div class="container responsive-content-box my-5 my-lg-0 pt-3 pt-lg-0">
   <div class="row">
     <div class="offset-lg-1 col-lg-11">
 

--- a/app/views/public/questions/index.html.erb
+++ b/app/views/public/questions/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container my-5 my-lg-0 pt-5 pt-lg-0">
+<div class="container responsive-content-box my-5 my-lg-0 pt-5 pt-lg-0">
   <div class="row">
     <div class="offset-lg-1 col-lg-11">
 

--- a/app/views/public/questions/search.html.erb
+++ b/app/views/public/questions/search.html.erb
@@ -1,18 +1,18 @@
-<div class="container my-5 my-lg-0">
+<div class="container responsive-content-box my-5 my-lg-0">
   <div class="row">
     <div class="offset-lg-1 col-lg-11">
 
       <% if @search_word.blank? || @questions.empty? %>
 
         <div class="content-box py-5 text-center", style="margin-top: 100px;">
-          <h5>お探しの質問はまだ投稿されていないようです。</h5>
+          <h5 class="m-3">お探しの質問はまだ投稿されていないようです。</h5>
           <%= link_to "質問する", new_question_path, class: "btn btn-primary mt-4" %>
         </div>
-        
+
         <% @questions = Question.all.order(id: "DESC").limit(5) %>
 
         <div class="content-box my-5">
-          <h5 class="ml-5">その他の人は、こんな質問をしています：</h5>
+          <h5 class="my-2 mx-3">その他の人は、こんな質問をしています</h5>
           <%= render 'one_question', questions: @questions %>
         </div>
 


### PR DESCRIPTION
以下の変更点を含みます。

### 会員側一部の一覧画面のみにスマホ表示時のpadding値の変更を適用

スマホ表示時のcontent-boxに関して、
CSS内にresponsive-content-boxクラスを追加することで、一部の一覧画面のみに適用を絞りました。

**該当画面**
・app/views/public/homes/top.html.erb
・app/views/public/posts/index.html.erb
・app/views/public/questions/index.html.erb
・app/views/public/questions/search.html.erb
・app/views/public/bookmarks/index.html.erb

**CSS**
【app/javascript/stylesheets/responsive.scss】
```
@media screen and (max-width:576px) {

・・・

  .responsive-content-box .content-box {
    padding: 20px 0;
  }
}
```