### PR TITLE
[Update] レスポンシブ表示時のマイページ内プロフィール画像の間隔を調整

### DIFF
--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -6,7 +6,7 @@
       <div class="content-box", style="margin: 100px 0;">
 
         <div class="row pt-md-4 px-md-4">
-          <div class="col-5 col-md-3 pt-2 pt-md-0" style="height: 150px; width: 150px;">
+          <div class="col-5 col-md-3 pt-2 pt-md-0 mb-3 mb-sm-5 mb-md-0" style="height: 150px; width: 150px;">
             <%= image_tag @user.get_profile_image(150, 150), class: "img-fluid rounded-circle mr-5", style: "border: 3px solid #066285;" %>
           </div>
           <div class="col-7 col-md-5 mt-4">


### PR DESCRIPTION
以下の変更点を含みます。

### レスポンシブ表示時のマイページ内プロフィール画像の間隔を調整
スマホ表示、タブレット表示時に他の要素と重ならないよう記述を変更しました。