### PR TITLE
[Update] 会員側のログインと管理者側のログインが干渉しないよう設定

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::SessionsController < Devise::SessionsController
+  before_action :sign_out_user!, only: [:new]
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -24,4 +25,11 @@ class Admin::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  private
+
+  def sign_out_user!
+    sign_out :user if user_signed_in?
+  end
+
 end

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Public::RegistrationsController < Devise::RegistrationsController
+  before_action :sign_out_admin!, only: [:new]
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
@@ -63,4 +64,11 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  private
+
+  def sign_out_admin!
+    sign_out :admin if admin_signed_in?
+  end
+
 end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Public::SessionsController < Devise::SessionsController
+  before_action :sign_out_admin!, only: [:new]
   # before_action :configure_sign_in_params, only: [:create]
-  
+
   def guest_sign_in
     user = User.guest
     sign_in user
@@ -30,4 +31,11 @@ class Public::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  private
+
+  def sign_out_admin!
+    sign_out :admin if admin_signed_in?
+  end
+
 end


### PR DESCRIPTION
以下の変更点を含みます。

### 会員側のログインと管理者側のログインが干渉しないよう設定
会員側でログインしている時、管理者側のログインページに遷移すると自動で会員側からログアウトします。
逆に、管理者側でログインしている時、会員側のログインor新規登録ページに遷移すると自動で管理者側からログアウトします。